### PR TITLE
Add cloud masks to intermediate Zarr

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 2.1.43
+current_version = 2.1.44
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 2.1.41
+current_version = 2.1.42
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 2.1.42
+current_version = 2.1.43
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -7,5 +7,3 @@ jobs:
     uses: openclimatefix/.github/.github/workflows/python-lint.yml@main
     with:
       folder: "satip"
-      # pytest-cov looks at this folder
-      pytest_cov_dir: "satip"

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -7,3 +7,5 @@ jobs:
     uses: openclimatefix/.github/.github/workflows/python-lint.yml@main
     with:
       folder: "satip"
+      # pytest-cov looks at this folder
+      pytest_cov_dir: "satip"

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -4,3 +4,8 @@ on: [push]
 jobs:
   call-run-python-tests:
     uses: openclimatefix/.github/.github/workflows/python-test.yml@main
+    with:
+      # 0 means don't use pytest-xdist
+      pytest_numcpus: "4"
+      # pytest-cov looks at this folder
+      pytest_cov_dir: "satip"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.19.4
 pandas>=1.1.4
 requests
 fsspec
-satpy>=0.30.1
+satpy[seviri_l2_grib]>=0.30.1
 zarr
 xarray
 bottleneck

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -112,7 +112,29 @@ class Compressor:
             return dataarray
         else:
             return None
+    
+    def compress_mask(self, dataarray: xr.DataArray) -> Union[xr.DataArray, None]:
+        """
+        Compresses Cloud masks DataArrays
+        
+        Args:
+            dataarray: DataArray to compress
 
+        Returns:
+            The compressed DataArray
+        """
+        da_meta = dataarray.attrs
+
+        dataarray = dataarray.reindex({"variable": self.variable_order}).transpose(
+            "time", "y", "x", "variable"
+        )
+        dataarray = dataarray.round().clip(min=0,max=3).astype(np.int16)
+        if is_dataset_clean(dataarray):
+            dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
+
+            return dataarray
+        else:
+            return None
 
 def is_dataset_clean(dataarray: xr.DataArray) -> bool:
     """

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -61,7 +61,7 @@ class Compressor:
         self.maxs = maxs
         self.variable_order = variable_order
 
-    def fit(self, dataset: xr.Dataset, dims: list = ["time", "y", "x"]) -> None:
+    def fit(self, dataset: xr.Dataset, dims: list = ["time", "y_osgb", "x_osgb"]) -> None:
         """
         Calculate new min and max values for the compression
 
@@ -96,7 +96,7 @@ class Compressor:
             ), f"{attr} must be set in initialisation or through `fit`"
 
         dataarray = dataarray.reindex({"variable": self.variable_order}).transpose(
-            "time", "y", "x", "variable"
+            "time", "y_osgb", "x_osgb", "variable"
         )
 
         upper_bound = (2 ** self.bits_per_pixel) - 1
@@ -126,7 +126,7 @@ class Compressor:
         da_meta = dataarray.attrs
 
         dataarray = dataarray.reindex({"variable": self.variable_order}).transpose(
-            "time", "y", "x", "variable"
+            "time", "y_osgb", "x_osgb", "variable"
         )
         dataarray = dataarray.round().clip(min=0,max=3).astype(np.int16)
         if is_dataset_clean(dataarray):

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -105,18 +105,18 @@ class Compressor:
         dataarray -= self.mins
         dataarray /= new_max
         dataarray *= upper_bound
-        dataarray = dataarray.round().clip(min=0,max=upper_bound).astype(np.int16)
+        dataarray = dataarray.round().clip(min=0, max=upper_bound).astype(np.int16)
         if is_dataset_clean(dataarray):
             dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
 
             return dataarray
         else:
             return None
-    
+
     def compress_mask(self, dataarray: xr.DataArray) -> Union[xr.DataArray, None]:
         """
         Compresses Cloud masks DataArrays
-        
+
         Args:
             dataarray: DataArray to compress
 
@@ -128,13 +128,14 @@ class Compressor:
         dataarray = dataarray.reindex({"variable": self.variable_order}).transpose(
             "time", "y_osgb", "x_osgb", "variable"
         )
-        dataarray = dataarray.round().clip(min=0,max=3).astype(np.int16)
+        dataarray = dataarray.round().clip(min=0, max=3).astype(np.int16)
         if is_dataset_clean(dataarray):
             dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
 
             return dataarray
         else:
             return None
+
 
 def is_dataset_clean(dataarray: xr.DataArray) -> bool:
     """

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -105,7 +105,7 @@ class Compressor:
         dataarray -= self.mins
         dataarray /= new_max
         dataarray *= upper_bound
-        dataarray = dataarray.round().astype(np.int16)
+        dataarray = dataarray.round().clip(min=0,max=upper_bound).astype(np.int16)
         if is_dataset_clean(dataarray):
             dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
 

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -106,12 +106,9 @@ class Compressor:
         dataarray /= new_max
         dataarray *= upper_bound
         dataarray = dataarray.round().clip(min=0, max=upper_bound).astype(np.int16)
-        if is_dataset_clean(dataarray):
-            dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
+        dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
 
-            return dataarray
-        else:
-            return None
+        return dataarray
 
     def compress_mask(self, dataarray: xr.DataArray) -> Union[xr.DataArray, None]:
         """
@@ -129,12 +126,9 @@ class Compressor:
             "time", "y_osgb", "x_osgb", "variable"
         )
         dataarray = dataarray.round().clip(min=0, max=3).astype(np.int16)
-        if is_dataset_clean(dataarray):
-            dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
+        dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
 
-            return dataarray
-        else:
-            return None
+        return dataarray
 
 
 def is_dataset_clean(dataarray: xr.DataArray) -> bool:

--- a/satip/download.py
+++ b/satip/download.py
@@ -60,7 +60,7 @@ def download_eumetsat_data(
     user_secret: Optional[str] = None,
     auth_filename: Optional[str] = None,
     number_of_processes: int = 0,
-    product: Union[str, List[str]] = ["rss", "cloud"],
+    product: Union[str, List[str]] = ["rss", "cloud"]
 ):
     """
     Downloads EUMETSAT RSS and Cloud Masks to the given directory,
@@ -142,29 +142,27 @@ def download_time_range(x: Tuple[Tuple[datetime, datetime], str, eumetsat.Downlo
     _LOG.info(format_dt_str(end_time))
     # To help stop with rate limiting
     time.sleep(np.random.randint(0, 30))
-    try:
-        download_manager.download_date_range(
-            format_dt_str(start_time),
-            format_dt_str(end_time),
-            product_id=product_id,
-        )
-    except requests.exceptions.ConnectionError:
-        # Retry again after 10 minutes, should then continue working if intermittent
-        time.sleep(600)
-        download_manager.download_date_range(
-            format_dt_str(start_time),
-            format_dt_str(end_time),
-            product_id=product_id,
-        )
-    except Exception as e:
-        _LOG.warning(f"An Error was thrown, waiting and trying again: {e}")
-        # Wait between 10 and 20 minutes and try again
-        time.sleep(np.random.randint(600, 1200))
-        download_manager.download_date_range(
-            format_dt_str(start_time),
-            format_dt_str(end_time),
-            product_id=product_id,
-        )
+    complete = False
+    while not complete:
+        try:
+            time.sleep(np.random.randint(0, 600))
+            download_manager.download_date_range(
+                format_dt_str(start_time),
+                format_dt_str(end_time),
+                product_id=product_id,
+            )
+            complete = True
+        except requests.exceptions.ConnectionError:
+            # Retry again after 10 minutes, should then continue working if intermittent
+            time.sleep(600)
+            download_manager.download_date_range(
+                format_dt_str(start_time),
+                format_dt_str(end_time),
+                product_id=product_id,
+            )
+            complete = True
+        except Exception as e:
+            _LOG.warning(f"An Error was thrown, waiting and trying again: {e}")
 
 
 def load_key_secret(filename: str) -> Tuple[str, str]:

--- a/satip/download.py
+++ b/satip/download.py
@@ -60,6 +60,7 @@ def download_eumetsat_data(
     user_secret: Optional[str] = None,
     auth_filename: Optional[str] = None,
     number_of_processes: int = 0,
+    product: Union[str, List[str]] = ["rss", "cloud"]
 ):
     """
     Downloads EUMETSAT RSS and Cloud Masks to the given directory,
@@ -74,6 +75,8 @@ def download_eumetsat_data(
         user_key: User key for the EUMETSAT API
         user_secret: User secret for the EUMETSAT API
         auth_filename: Path to a file containing the user_secret and user_key
+        number_of_processes: Number of processes to use
+        product: Which product(s) to download
 
     """
     # Get authentication
@@ -91,11 +94,12 @@ def download_eumetsat_data(
 
     # Download the data
     dm = eumetsat.DownloadManager(user_key, user_secret, download_directory, download_directory)
-
-    for product_id in [
-        RSS_ID,
-        CLOUD_ID,
-    ]:
+    products_to_use = []
+    if "rss" in product:
+        products_to_use.append(RSS_ID)
+    if "cloud" in product:
+        products_to_use.append(CLOUD_ID)
+    for product_id in products_to_use:
         # Do this to clear out any partially downloaded days
         sanity_check_files_and_move_to_directory(
             directory=download_directory, product_id=product_id

--- a/satip/download.py
+++ b/satip/download.py
@@ -60,7 +60,7 @@ def download_eumetsat_data(
     user_secret: Optional[str] = None,
     auth_filename: Optional[str] = None,
     number_of_processes: int = 0,
-    product: Union[str, List[str]] = ["rss", "cloud"]
+    product: Union[str, List[str]] = ["rss", "cloud"],
 ):
     """
     Downloads EUMETSAT RSS and Cloud Masks to the given directory,

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -313,9 +313,7 @@ class DownloadManager:
 
         # Downloading specified datasets
         if not dataset_ids:
-            self.logger.info(
-                "No files will be downloaded. Set DownloadManager bucket_name argument for local download"
-            )
+            self.logger.info("No files will be downloaded. None were found in API search.")
             return
 
         for dataset_id in dataset_ids:

--- a/satip/intermediate.py
+++ b/satip/intermediate.py
@@ -8,7 +8,7 @@ import xarray as xr
 from tqdm import tqdm
 
 from satip.eumetsat import eumetsat_cloud_name_to_datetime, eumetsat_filename_to_datetime
-from satip.utils import check_if_timestep_exists, load_native_to_dataset, save_dataset_to_zarr
+from satip.utils import check_if_timestep_exists, load_native_to_dataset, save_dataset_to_zarr, load_cloudmask_to_dataset
 
 
 def split_per_month(

--- a/satip/intermediate.py
+++ b/satip/intermediate.py
@@ -8,7 +8,12 @@ import xarray as xr
 from tqdm import tqdm
 
 from satip.eumetsat import eumetsat_cloud_name_to_datetime, eumetsat_filename_to_datetime
-from satip.utils import check_if_timestep_exists, load_native_to_dataset, save_dataset_to_zarr, load_cloudmask_to_dataset
+from satip.utils import (
+    check_if_timestep_exists,
+    load_cloudmask_to_dataset,
+    load_native_to_dataset,
+    save_dataset_to_zarr,
+)
 
 
 def split_per_month(
@@ -89,10 +94,18 @@ def wrapper(args):
         dirs, zarrs, hrv_zarrs, temp_directory, region, spatial_chunk_size, temporal_chunk_size
     )
 
-def create_or_update_zarr_with_cloud_mask_files(directory: str, zarr_path: str, temp_directory: Path, region: str, spatial_chunk_size: int = 256, temporal_chunk_size: int = 1) -> None:
+
+def create_or_update_zarr_with_cloud_mask_files(
+    directory: str,
+    zarr_path: str,
+    temp_directory: Path,
+    region: str,
+    spatial_chunk_size: int = 256,
+    temporal_chunk_size: int = 1,
+) -> None:
     """
     Creates or updates a zarr file with the cloud mask files
-    
+
     Args:
         directory: Top-level directory containing the compressed native files
         zarr_path: Path of the final Zarr file
@@ -134,6 +147,7 @@ def create_or_update_zarr_with_cloud_mask_files(directory: str, zarr_path: str, 
             del dataset
         except Exception as e:
             print(f"Failed with Exception with {e}")
+
 
 def create_or_update_zarr_with_native_files(
     directory: str,

--- a/satip/intermediate.py
+++ b/satip/intermediate.py
@@ -42,28 +42,27 @@ def split_per_month(
     for year in year_directories:
         if not os.path.isdir(os.path.join(directory, year)):
             continue
-        if year in ["2020", "2021"]:
-            month_directories = os.listdir(os.path.join(directory, year))
-            for month in month_directories:
-                if not os.path.isdir(os.path.join(directory, year, month)):
-                    continue
-                month_directory = os.path.join(directory, year.split("/")[0], month.split("/")[0])
-                month_zarr_path = zarr_path + f"_{year.split('/')[0]}_{month.split('/')[0]}.zarr"
-                hrv_month_zarr_path = (
-                    hrv_zarr_path + f"_{year.split('/')[0]}" f"_{month.split('/')[0]}.zarr"
+        month_directories = os.listdir(os.path.join(directory, year))
+        for month in month_directories:
+            if not os.path.isdir(os.path.join(directory, year, month)):
+                continue
+            month_directory = os.path.join(directory, year.split("/")[0], month.split("/")[0])
+            month_zarr_path = zarr_path + f"_{year.split('/')[0]}_{month.split('/')[0]}.zarr"
+            hrv_month_zarr_path = (
+                hrv_zarr_path + f"_{year.split('/')[0]}" f"_{month.split('/')[0]}.zarr"
+            )
+            dirs.append(month_directory)
+            zarrs.append(month_zarr_path)
+            hrv_zarrs.append(hrv_month_zarr_path)
+            zarr_exists = os.path.exists(month_zarr_path)
+            if not zarr_exists:
+                # Inital zarr path before then appending
+                compressed_native_files = list(Path(month_directory).rglob("*.bz2"))
+                dataset, hrv_dataset = load_native_to_dataset(
+                    compressed_native_files[0], temp_directory, region
                 )
-                dirs.append(month_directory)
-                zarrs.append(month_zarr_path)
-                hrv_zarrs.append(hrv_month_zarr_path)
-                zarr_exists = os.path.exists(month_zarr_path)
-                if not zarr_exists:
-                    # Inital zarr path before then appending
-                    compressed_native_files = list(Path(month_directory).rglob("*.bz2"))
-                    dataset, hrv_dataset = load_native_to_dataset(
-                        compressed_native_files[0], temp_directory, region
-                    )
-                    save_dataset_to_zarr(dataset, zarr_path=month_zarr_path, zarr_mode="w")
-                    save_dataset_to_zarr(hrv_dataset, zarr_path=hrv_month_zarr_path, zarr_mode="w")
+                save_dataset_to_zarr(dataset, zarr_path=month_zarr_path, zarr_mode="w")
+                save_dataset_to_zarr(hrv_dataset, zarr_path=hrv_month_zarr_path, zarr_mode="w")
     print(dirs)
     print(zarrs)
     pool = multiprocessing.Pool(processes=16)

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -171,6 +171,7 @@ def convert_scene_to_dataarray(scene: Scene, band: str, area: str) -> xr.DataArr
 
     # Stack DataArrays in the Dataset into a single DataArray
     dataarray = dataset.to_array()
+    dataarray = dataarray.rename({"x": "x_osgb", "y": "y_osgb"})
     if "time" not in dataarray.dims:
         time = pd.to_datetime(dataset.attrs["end_time"])
         dataarray = add_constant_coord_to_dataarray(dataarray, "time", time)

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -156,6 +156,7 @@ def load_native_to_dataset(
     else:
         return None, None
 
+
 def load_cloudmask_to_dataset(
     filename: Path, temp_directory: Path, area: str
 ) -> Union[xr.DataArray, None]:
@@ -170,9 +171,7 @@ def load_cloudmask_to_dataset(
     Returns:
         Returns Xarray DataArray if script worked, else returns None
     """
-    compressor = Compressor(
-        variable_order=["cloud_mask"], maxs=np.array([3]), mins=np.array([0])
-    )
+    compressor = Compressor(variable_order=["cloud_mask"], maxs=np.array([3]), mins=np.array([0]))
     scene = Scene(filenames={"seviri_l2_grib": [decompressed_filename]})
     scene.load(
         [
@@ -189,6 +188,7 @@ def load_cloudmask_to_dataset(
         return dataarray
     else:
         return None
+
 
 def convert_scene_to_dataarray(scene: Scene, band: str, area: str) -> xr.DataArray:
     scene = scene.crop(ll_bbox=GEOGRAPHIC_BOUNDS[area])
@@ -213,9 +213,9 @@ def convert_scene_to_dataarray(scene: Scene, band: str, area: str) -> xr.DataArr
 
     # Fill NaN's but only if its a short amount of NaNs
     # NaN's for off-disk would not be filled
-    dataarray = dataarray.interpolate_na(dim="x_osgb", max_gap=2, use_coordinate=False).interpolate_na(
-        dim="y_osgb", max_gap=2
-    )
+    dataarray = dataarray.interpolate_na(
+        dim="x_osgb", max_gap=2, use_coordinate=False
+    ).interpolate_na(dim="y_osgb", max_gap=2)
 
     return dataarray
 

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -185,7 +185,7 @@ def load_cloudmask_to_dataset(
     # If any NaNs still exist, then don't return it
     if is_dataset_clean(dataarray):
         # Compress and return
-        dataarray = compressor.compress(dataarray)
+        dataarray = compressor.compress_mask(dataarray)
         return dataarray
     else:
         return None

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -173,7 +173,7 @@ def load_cloudmask_to_dataset(
     compressor = Compressor(
         variable_order=["cloud_mask"], maxs=np.array([3]), mins=np.array([0])
     )
-    scene = Scene(filenames={"seviri_l1b_grib": [decompressed_filename]})
+    scene = Scene(filenames={"seviri_l2_grib": [decompressed_filename]})
     scene.load(
         [
             "cloud_mask",

--- a/scripts/cloudmask.py
+++ b/scripts/cloudmask.py
@@ -1,0 +1,9 @@
+import satpy
+from satpy import Scene
+from satpy import available_readers
+print(available_readers())
+
+decompressed_nat = "/run/timeshift/backup/MSG3-SEVI-MSG15-0100-NA-20210103235915.986000000Z-NA.nat"
+grb = "/run/timeshift/backup/MSG3-SEVI-MSGCLMK-0100-0100-20210104000000.000000000Z-NA.grb"
+
+scene = Scene(filenames={"seviri_l1b_native": [decompressed_nat], "seviri_l2_grib": [grb]})

--- a/scripts/cloudmask.py
+++ b/scripts/cloudmask.py
@@ -1,6 +1,6 @@
 import satpy
-from satpy import Scene
-from satpy import available_readers
+from satpy import Scene, available_readers
+
 print(available_readers())
 
 decompressed_nat = "/run/timeshift/backup/MSG3-SEVI-MSG15-0100-NA-20210103235915.986000000Z-NA.nat"

--- a/scripts/get_raw_eumetsat_data.py
+++ b/scripts/get_raw_eumetsat_data.py
@@ -90,7 +90,7 @@ def validate_date(ctx, param, value):
     "--product",
     "--p",
     multiple=True,
-    default=["rss","cloud"],
+    default=["rss", "cloud"],
     help="Which products to download, of 'rss' and 'cloud' ",
 )
 def download_sat_files(*args, **kwargs):

--- a/scripts/get_raw_eumetsat_data.py
+++ b/scripts/get_raw_eumetsat_data.py
@@ -79,6 +79,20 @@ def validate_date(ctx, param, value):
     prompt="Bandwidth limit, in MB/sec, currently ignored",
     type=float,
 )
+@click.option(
+    "--number_of_processes",
+    "--np",
+    default=4,
+    prompt="Number of processes to use",
+    type=int,
+)
+@click.option(
+    "--product",
+    "--p",
+    multiple=True,
+    default=["rss","cloud"],
+    help="Which products to download, of 'rss' and 'cloud' ",
+)
 def download_sat_files(*args, **kwargs):
     satip.download.download_eumetsat_data(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = (this_directory / "requirements.txt").read_text().splitlines(
 
 setup(
     name="satip",
-    version="2.1.43",
+    version="2.1.44",
     license="MIT",
     description="Satip provides the functionality necessary for retrieving, and storing EUMETSAT data",
     author="Jacob Bieker, Ayrton Bourn",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = (this_directory / "requirements.txt").read_text().splitlines(
 
 setup(
     name="satip",
-    version="2.1.42",
+    version="2.1.43",
     license="MIT",
     description="Satip provides the functionality necessary for retrieving, and storing EUMETSAT data",
     author="Jacob Bieker, Ayrton Bourn",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = (this_directory / "requirements.txt").read_text().splitlines(
 
 setup(
     name="satip",
-    version="2.1.41",
+    version="2.1.42",
     license="MIT",
     description="Satip provides the functionality necessary for retrieving, and storing EUMETSAT data",
     author="Jacob Bieker, Ayrton Bourn",


### PR DESCRIPTION
# Pull Request

## Description

Adds saving cloud mask data into the intermediate Zarr, for the non-HRV channels, as that is what the cloud mask resolution matches.

Probably will put the cloud masks in their own Zarr file, as they might have a different availability than the native files. Some days seem to be missing half of the cloud masks, but none of the native files, for example.

Whats left to do:

- [x] Update datetime checks to use actual datetimes, not seconds since epoch
- [x] Add a final sort of the datetimes in the zarr after script finishes -> Needed for nowcasting dataset to do slicing
- [ ] Test run

Fixes #39 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] No
- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
