### PR TITLE
Fix coordinates

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -3,6 +3,8 @@ from typing import Union
 import numpy as np
 import xarray as xr
 
+from satip.utils import serialize_attrs
+
 
 class Compressor:
     def __init__(
@@ -61,7 +63,7 @@ class Compressor:
         self.maxs = maxs
         self.variable_order = variable_order
 
-    def fit(self, dataset: xr.Dataset, dims: list = ["time", "y_osgb", "x_osgb"]) -> None:
+    def fit(self, dataset: xr.Dataset, dims: list = ("time", "y", "x")) -> None:
         """
         Calculate new min and max values for the compression
 
@@ -70,6 +72,7 @@ class Compressor:
             dims: Dims to compute over
 
         """
+        dims = list(dims)
         self.mins = dataset.min(dims).compute()
         self.maxs = dataset.max(dims).compute()
         self.variable_order = dataset.coords["variable"].values
@@ -88,15 +91,13 @@ class Compressor:
         Returns:
             The compressed DataArray
         """
-        da_meta = dataarray.attrs
-
         for attr in ["mins", "maxs"]:
             assert (
                 getattr(self, attr) is not None
             ), f"{attr} must be set in initialisation or through `fit`"
 
         dataarray = dataarray.reindex({"variable": self.variable_order}).transpose(
-            "time", "y_osgb", "x_osgb", "variable"
+            "time", "y", "x", "variable"
         )
 
         upper_bound = (2 ** self.bits_per_pixel) - 1
@@ -106,7 +107,7 @@ class Compressor:
         dataarray /= new_max
         dataarray *= upper_bound
         dataarray = dataarray.round().clip(min=0, max=upper_bound).astype(np.int16)
-        dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
+        dataarray.attrs = serialize_attrs(dataarray.attrs)  # Must be serializable
 
         return dataarray
 
@@ -120,13 +121,11 @@ class Compressor:
         Returns:
             The compressed DataArray
         """
-        da_meta = dataarray.attrs
-
         dataarray = dataarray.reindex({"variable": self.variable_order}).transpose(
-            "time", "y_osgb", "x_osgb", "variable"
+            "time", "y", "x", "variable"
         )
         dataarray = dataarray.round().clip(min=0, max=3).astype(np.int16)
-        dataarray.attrs = {"meta": str(da_meta)}  # Must be serializable
+        dataarray.attrs = serialize_attrs(dataarray.attrs)  # Must be serializable
 
         return dataarray
 

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -1,4 +1,4 @@
-from typing import Union, Iterable
+from typing import Iterable, Union
 
 import numpy as np
 import xarray as xr

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -3,7 +3,7 @@ from typing import Union
 import numpy as np
 import xarray as xr
 
-from satip.utils import serialize_attrs
+from satip.serialize import serialize_attrs
 
 
 class Compressor:

--- a/satip/compression.py
+++ b/satip/compression.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Iterable
 
 import numpy as np
 import xarray as xr
@@ -63,7 +63,7 @@ class Compressor:
         self.maxs = maxs
         self.variable_order = variable_order
 
-    def fit(self, dataset: xr.Dataset, dims: list = ("time", "y", "x")) -> None:
+    def fit(self, dataset: xr.Dataset, dims: Iterable = ("time", "y", "x")) -> None:
         """
         Calculate new min and max values for the compression
 

--- a/satip/geospatial.py
+++ b/satip/geospatial.py
@@ -18,7 +18,8 @@ WGS84 = 4326
 WGS84_CRS = f"EPSG:{WGS84}"
 
 # Geographic bounds for various regions of interest, in order of min_lon, min_lat, max_lon, max_lat
-GEOGRAPHIC_BOUNDS = {"UK": (-16, 45, 10, 62), "RSS": (-64, 83, 16, 69)}
+# (see https://satpy.readthedocs.io/en/stable/_modules/satpy/scene.html)
+GEOGRAPHIC_BOUNDS = {"UK": (-16, 45, 10, 62), "RSS": (-64, 16, 83, 69)}
 
 
 class Transformers:

--- a/satip/geospatial.py
+++ b/satip/geospatial.py
@@ -17,7 +17,7 @@ OSGB = 27700
 WGS84 = 4326
 WGS84_CRS = f"EPSG:{WGS84}"
 
-# Geographic bounds for various regions of interest, in order of min_lon, max_lon, min_lat, max_lat
+# Geographic bounds for various regions of interest, in order of min_lon, min_lat, max_lon, max_lat
 GEOGRAPHIC_BOUNDS = {"UK": (-16, 45, 10, 62), "RSS": (-64, 83, 16, 69)}
 
 
@@ -25,38 +25,17 @@ class Transformers:
     """
     Class to store transformation from one Grid to another.
 
-    Its good to make this only once, but need the
+    It's good to make this only once, but need the
     option of updating them, due to out of data grids.
     """
 
     def __init__(self):
         """Init"""
-        self._lat_lon_to_osgb = None
-        self.make_transformers()
-
-    def make_transformers(self):
-        """
-        Make transformers
-
-         Nice to only make these once, as it makes calling the functions below quicker
-        """
-        self._lat_lon_to_osgb = pyproj.Transformer.from_crs(crs_from=WGS84, crs_to=OSGB)
-
-    @property
-    def lat_lon_to_osgb(self):
-        """lat-lon to OSGB property"""
-        return self._lat_lon_to_osgb
+        self.lat_lon_to_osgb = pyproj.Transformer.from_crs(crs_from=WGS84, crs_to=OSGB)
 
 
 # make the transformers
-transformers = Transformers()
-
-
-def download_grids():
-    """The transformer grid sometimes need updating"""
-    pyproj.transformer.TransformerGroup(crs_from=WGS84, crs_to=OSGB).download_grids(verbose=True)
-
-    transformers.make_transformers()
+_transformers = Transformers()
 
 
 def lat_lon_to_osgb(lat: List[Number], lon: List[Number]) -> Tuple[np.ndarray, np.ndarray]:
@@ -70,4 +49,4 @@ def lat_lon_to_osgb(lat: List[Number], lon: List[Number]) -> Tuple[np.ndarray, n
     Return: 2-tuple of x (east-west), y (north-south).
 
     """
-    return transformers.lat_lon_to_osgb.transform(lat, lon)
+    return _transformers.lat_lon_to_osgb.transform(lat, lon)

--- a/satip/serialize.py
+++ b/satip/serialize.py
@@ -1,7 +1,8 @@
+import datetime
+
 import numpy as np
 import pyresample
 import yaml
-import datetime
 
 
 def serialize_attrs(attrs: dict) -> dict:

--- a/satip/serialize.py
+++ b/satip/serialize.py
@@ -37,7 +37,7 @@ def serialize_attrs(attrs: dict) -> dict:
         if isinstance(value, pyresample.geometry.AreaDefinition):
             attrs[attr_key] = value.dump()
 
-        if isinstance(value, datetime):
+        if isinstance(value, datetime.datetime):
             attrs[attr_key] = value.isoformat()
 
     return attrs

--- a/satip/serialize.py
+++ b/satip/serialize.py
@@ -1,0 +1,38 @@
+import pyresample
+import yaml
+import numpy as np
+
+
+def serialize_attrs(attrs: dict) -> dict:
+    """Ensure each value of dict can be serialized.
+
+    This is required before saving to Zarr because Zarr represents attrs values in a
+    JSON file (.zmetadata).
+
+    The `area` field (which is a `pyresample.geometry.AreaDefinition` object gets turned
+    into a YAML string, which can be loaded again using
+    `area_definition = pyresample.area_config.load_area_from_string(data_array.attrs['area'])`
+
+    Returns attrs dict where every value has been made serializable.
+    """
+    for attr_key in attrs:
+        value = attrs[attr_key]
+
+        # Convert Dicts
+        if isinstance(value, dict):
+            # Convert np.float32 to Python floats (otherwise yaml.dump complains)
+            for inner_key in value:
+                inner_value = value[inner_key]
+                if isinstance(inner_value, np.floating):
+                    value[inner_key] = float(inner_value)
+            attrs[attr_key] = yaml.dump(value)
+
+        # Convert Numpy bools
+        if isinstance(value, (bool, np.bool_)):
+            attrs[attr_key] = str(value)
+
+        # Convert area
+        if isinstance(value, pyresample.geometry.AreaDefinition):
+            attrs[attr_key] = value.dump()
+
+    return attrs

--- a/satip/serialize.py
+++ b/satip/serialize.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pyresample
 import yaml
+import datetime
 
 
 def serialize_attrs(attrs: dict) -> dict:
@@ -34,5 +35,8 @@ def serialize_attrs(attrs: dict) -> dict:
         # Convert area
         if isinstance(value, pyresample.geometry.AreaDefinition):
             attrs[attr_key] = value.dump()
+
+        if isinstance(value, datetime):
+            attrs[attr_key] = value.isoformat()
 
     return attrs

--- a/satip/serialize.py
+++ b/satip/serialize.py
@@ -1,6 +1,6 @@
+import numpy as np
 import pyresample
 import yaml
-import numpy as np
 
 
 def serialize_attrs(attrs: dict) -> dict:

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -9,13 +9,12 @@ from typing import Any, Tuple
 import numcodecs
 import numpy as np
 import pandas as pd
-import pyresample
 import xarray as xr
-import yaml
 from satpy import Scene
 
 from satip.compression import Compressor, is_dataset_clean
 from satip.geospatial import GEOGRAPHIC_BOUNDS, lat_lon_to_osgb
+from satip.serialize import serialize_attrs
 
 warnings.filterwarnings("ignore", message="divide by zero encountered in true_divide")
 warnings.filterwarnings("ignore", message="invalid value encountered in sin")
@@ -194,41 +193,6 @@ def load_cloudmask_to_dataset(filename: Path, temp_directory: Path, area: str) -
     # Convert 3's to NaNs as they should be No Data/Space
     dataarray = dataarray.where(dataarray["variable"] != 3)
     return dataarray
-
-
-def serialize_attrs(attrs: dict) -> dict:
-    """Ensure each value of dict can be serialized.
-
-    This is required before saving to Zarr because Zarr represents attrs values in a
-    JSON file (.zmetadata).
-
-    The `area` field (which is a `pyresample.geometry.AreaDefinition` object gets turned
-    into a YAML string, which can be loaded again using
-    `area_definition = pyresample.area_config.load_area_from_string(data_array.attrs['area'])`
-
-    Returns attrs dict where every value has been made serializable.
-    """
-    for attr_key in attrs:
-        value = attrs[attr_key]
-
-        # Convert Dicts
-        if isinstance(value, dict):
-            # Convert np.float32 to Python floats (otherwise yaml.dump complains)
-            for inner_key in value:
-                inner_value = value[inner_key]
-                if isinstance(inner_value, np.floating):
-                    value[inner_key] = float(inner_value)
-            attrs[attr_key] = yaml.dump(value)
-
-        # Convert Numpy bools
-        if isinstance(value, (bool, np.bool_)):
-            attrs[attr_key] = str(value)
-
-        # Convert area
-        if isinstance(value, pyresample.geometry.AreaDefinition):
-            attrs[attr_key] = value.dump()
-
-    return attrs
 
 
 def convert_scene_to_dataarray(scene: Scene, band: str, area: str) -> xr.DataArray:


### PR DESCRIPTION
# Pull Request

## Description

* Fix the OSGB coordinates issue: Use the original `x` and `y` geostationary coordinates as the 'main' coordinates. Also add a 2D `x_osgb` coordinate, and a 2D `y_osgb` coordinate.
* Serialize the `dataarray.attrs` in a way that makes all the information easy to recover from the Zarr.
* Fix the ordering of the GEOGRAPHIC_BOUNDS.

## How Has This Been Tested?

`py.test` runs and the GitHub actions CI tests pass.  (Well, the linting doesn't pass, but that'll be fixed separately in issue #54)

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
