### PR TITLE
Reduce memory consumption of app.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ RUN source activate ${CONDA_ENV_NAME} && pip install -e .
 SHELL ["conda", "run", "-n", "satip", "/bin/bash", "-c"]
 
 # Example commnad that can be used, need to set API_KEY, API_SECRET and SAVE_DIR
-CMD ["conda", "run", "--no-capture-output", "-n", "satip", "python", "-u","scripts/app.py"]
+CMD ["conda", "run", "--no-capture-output", "-n", "satip", "python", "-u","satip/app.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ imagecodecs
 pyorbital
 netCDF4
 click
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ imagecodecs
 pyorbital
 netCDF4
 click
+

--- a/satip/app.py
+++ b/satip/app.py
@@ -14,6 +14,7 @@ from satip.utils import save_native_to_netcdf
 logging.basicConfig(format="%(asctime)s %(name)s %(levelname)s:%(message)s")
 logging.getLogger("satip").setLevel(getattr(logging, os.environ.get("LOG_LEVEL", "INFO")))
 logger = logging.getLogger(__name__)
+logging.getLogger(__name__).setLevel(logging.INFO)
 
 
 @click.command()

--- a/satip/app.py
+++ b/satip/app.py
@@ -9,7 +9,7 @@ import fsspec
 import pandas as pd
 
 from satip.eumetsat import DownloadManager
-from satip.utils import save_native_to_netcdf
+from satip.utils import save_native_to_netcdf, filter_dataset_ids_on_current_files
 
 logging.basicConfig(format="%(asctime)s %(name)s %(levelname)s:%(message)s")
 logging.getLogger("satip").setLevel(getattr(logging, os.environ.get("LOG_LEVEL", "INFO")))
@@ -62,10 +62,11 @@ def run(api_key, api_secret, save_dir, history):
         download_manager = DownloadManager(
             user_key=api_key, user_secret=api_secret, data_dir=tmpdir
         )
-        download_manager.download_date_range(
-            start_date=(pd.Timestamp.now() - pd.Timedelta(history)).strftime("%Y-%m-%d-%H-%M-%S"),
-            end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"),
-        )
+        datasets = download_manager.identify_available_datasets(start_date=(pd.Timestamp.now() - pd.Timedelta(history)).strftime("%Y-%m-%d-%H-%M-%S"), end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"))
+        # Filter out ones that already exist
+        datasets = filter_dataset_ids_on_current_files(datasets, save_dir)
+        download_manager.download_datasets(datasets)
+
         # 2. Load nat files to one Xarray Dataset
         native_files = list(glob.glob(os.path.join(tmpdir, "*.nat")))
 

--- a/satip/app.py
+++ b/satip/app.py
@@ -2,10 +2,10 @@
 import glob
 import logging
 import os
+import tempfile
 
 import click
 import fsspec
-import tempfile
 import pandas as pd
 
 from satip.eumetsat import DownloadManager
@@ -58,13 +58,15 @@ def run(api_key, api_secret, save_dir, history):
     logger.info(f'Running application and saving to "{save_dir}"')
     # 1. Get data from API, download native files
     with tempfile.TemporaryDirectory() as tmpdir:
-        download_manager = DownloadManager(user_key=api_key, user_secret=api_secret, data_dir=tmpdir)
+        download_manager = DownloadManager(
+            user_key=api_key, user_secret=api_secret, data_dir=tmpdir
+        )
         download_manager.download_date_range(
             start_date=(pd.Timestamp.now() - pd.Timedelta(history)).strftime("%Y-%m-%d-%H-%M-%S"),
             end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"),
         )
         # 2. Load nat files to one Xarray Dataset
-        native_files = list(glob.glob(os.path.join(tmpdir,"*.nat")))
+        native_files = list(glob.glob(os.path.join(tmpdir, "*.nat")))
 
         # Save to S3
         save_native_to_netcdf(native_files, save_dir=save_dir)

--- a/satip/app.py
+++ b/satip/app.py
@@ -68,6 +68,7 @@ def run(api_key, api_secret, save_dir, history):
         )
         # Filter out ones that already exist
         datasets = filter_dataset_ids_on_current_files(datasets, save_dir)
+        logger.info(f"Files to download after filtering: {len(datasets)}")
         download_manager.download_datasets(datasets)
 
         # 2. Load nat files to one Xarray Dataset

--- a/satip/app.py
+++ b/satip/app.py
@@ -4,6 +4,8 @@ import logging
 import os
 
 import click
+import fsspec
+import tempfile
 import pandas as pd
 
 from satip.eumetsat import DownloadManager
@@ -55,18 +57,19 @@ def run(api_key, api_secret, save_dir, history):
 
     logger.info(f'Running application and saving to "{save_dir}"')
     # 1. Get data from API, download native files
-    download_manager = DownloadManager(user_key=api_key, user_secret=api_secret, data_dir=save_dir)
-    download_manager.download_date_range(
-        start_date=(pd.Timestamp.now() - pd.Timedelta(history)).strftime("%Y-%m-%d-%H-%M-%S"),
-        end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"),
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        download_manager = DownloadManager(user_key=api_key, user_secret=api_secret, data_dir=tmpdir)
+        download_manager.download_date_range(
+            start_date=(pd.Timestamp.now() - pd.Timedelta(history)).strftime("%Y-%m-%d-%H-%M-%S"),
+            end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"),
+        )
+        # 2. Load nat files to one Xarray Dataset
+        native_files = list(glob.glob(os.path.join(tmpdir,"*.nat")))
 
-    # 2. Load grib files to one Xarray Dataset
-    native_files = list(glob.glob(os.path.join(save_dir, "*.nat")))
-    # data = datahub.load_all_files()
-    save_native_to_netcdf(native_files, save_dir=save_dir)
+        # Save to S3
+        save_native_to_netcdf(native_files, save_dir=save_dir)
 
-    logger.info("Finished Running application.")
+        logger.info("Finished Running application.")
 
 
 if __name__ == "__main__":

--- a/satip/app.py
+++ b/satip/app.py
@@ -9,7 +9,7 @@ import fsspec
 import pandas as pd
 
 from satip.eumetsat import DownloadManager
-from satip.utils import save_native_to_netcdf, filter_dataset_ids_on_current_files
+from satip.utils import filter_dataset_ids_on_current_files, save_native_to_netcdf
 
 logging.basicConfig(format="%(asctime)s %(name)s %(levelname)s:%(message)s")
 logging.getLogger("satip").setLevel(getattr(logging, os.environ.get("LOG_LEVEL", "INFO")))
@@ -62,7 +62,10 @@ def run(api_key, api_secret, save_dir, history):
         download_manager = DownloadManager(
             user_key=api_key, user_secret=api_secret, data_dir=tmpdir
         )
-        datasets = download_manager.identify_available_datasets(start_date=(pd.Timestamp.now() - pd.Timedelta(history)).strftime("%Y-%m-%d-%H-%M-%S"), end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"))
+        datasets = download_manager.identify_available_datasets(
+            start_date=(pd.Timestamp.now() - pd.Timedelta(history)).strftime("%Y-%m-%d-%H-%M-%S"),
+            end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"),
+        )
         # Filter out ones that already exist
         datasets = filter_dataset_ids_on_current_files(datasets, save_dir)
         download_manager.download_datasets(datasets)

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -18,10 +18,10 @@ import re
 import time
 import urllib
 import zipfile
-import fsspec
 from io import BytesIO
 from urllib.error import HTTPError
 
+import fsspec
 import requests
 
 from satip import utils

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -301,9 +301,7 @@ class DownloadManager:  # noqa: D205
         r.raise_for_status()
 
         zipped_files = zipfile.ZipFile(BytesIO(r.content))
-        # save to s3
-        filesystem = fsspec.open(self.data_dir).fs
-        zipped_files.extractall(filesystem)
+        zipped_files.extractall(f"{self.data_dir}")
 
         return
 

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -18,6 +18,7 @@ import re
 import time
 import urllib
 import zipfile
+import fsspec
 from io import BytesIO
 from urllib.error import HTTPError
 
@@ -300,7 +301,9 @@ class DownloadManager:  # noqa: D205
         r.raise_for_status()
 
         zipped_files = zipfile.ZipFile(BytesIO(r.content))
-        zipped_files.extractall(f"{self.data_dir}")
+        # save to s3
+        filesystem = fsspec.open(self.data_dir).fs
+        zipped_files.extractall(filesystem)
 
         return
 

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -590,7 +590,7 @@ def filter_dataset_ids_on_current_files(datasets, save_dir):
     datetimes = [pd.Timestamp(eumetsat_filename_to_datetime(idx)).round("5 min") for idx in ids]
     finished_datetimes = []
     for date in finished_files:
-        finished_datetimes.append(pd.to_datetime(date.split(".nc")[0], format="%Y%m%d%H%M", errors='ignore'))
+        finished_datetimes.append(pd.to_datetime(date.split(".nc")[0].split("/")[-1], format="%Y%m%d%H%M", errors='ignore'))
     idx_to_remove = []
     for idx, date in enumerate(datetimes):
         if date in finished_datetimes:

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -579,21 +579,25 @@ def save_to_netcdf_to_s3(dataset: xr.Dataset, filename: str):
     with tempfile.TemporaryDirectory() as dir:
         # save locally
         path = f"{dir}/temp.netcdf"
-        dataset.to_netcdf(path=path, mode="w", engine="h5netcdf", invalid_netcdf = True)
+        dataset.to_netcdf(path=path, mode="w", engine="h5netcdf", invalid_netcdf=True)
 
         # save to s3
         filesystem = fsspec.open(filename).fs
         filesystem.put(path, filename)
 
+
 def filter_dataset_ids_on_current_files(datasets, save_dir):
     from satip.eumetsat import eumetsat_filename_to_datetime
+
     ids = [dataset["id"] for dataset in datasets]
     filesystem = fsspec.open(save_dir).fs
     finished_files = filesystem.glob("*.nc")
     datetimes = [pd.Timestamp(eumetsat_filename_to_datetime(idx)).round("5 min") for idx in ids]
     finished_datetimes = []
     for date in finished_files:
-        finished_datetimes.append(pd.to_datetime(date.split(".nc")[0], format="%Y%m%d%H%M", errors='ignore'))
+        finished_datetimes.append(
+            pd.to_datetime(date.split(".nc")[0], format="%Y%m%d%H%M", errors="ignore")
+        )
     idx_to_remove = []
     for idx, date in enumerate(datetimes):
         if date in finished_datetimes:
@@ -604,6 +608,7 @@ def filter_dataset_ids_on_current_files(datasets, save_dir):
         if idx < len(datasets):
             datasets.pop(idx)
     return datasets
+
 
 # Cell
 def set_up_logging(

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -12,13 +12,13 @@ import datetime
 import logging
 import os
 import subprocess
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Any, Tuple
 
-import numcodecs
-import tempfile
 import fsspec
+import numcodecs
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -396,7 +396,7 @@ def save_native_to_netcdf(
             )
             hrv_dataset = hrv_dataarray.to_dataset(name="data")
             now_time = hrv_dataset["time"].strftime("%Y%m%d%H%M")
-            save_file = os.path.join(save_dir, f'hrv_{now_time}.nc')
+            save_file = os.path.join(save_dir, f"hrv_{now_time}.nc")
             logger.info(f"Saving HRV netcdf in {save_file}")
             save_to_netcdf_to_s3(hrv_dataset, save_file)
 
@@ -424,10 +424,9 @@ def save_native_to_netcdf(
         dataarray = dataarray.transpose("time", "y_geostationary", "x_geostationary", "variable")
         dataset = dataarray.to_dataset(name="data")
         now_time = dataset["time"].strftime("%Y%m%d%H%M")
-        save_file = os.path.join(save_dir, f'{now_time}.nc')
+        save_file = os.path.join(save_dir, f"{now_time}.nc")
         logger.info(f"Saving non-HRV netcdf in {save_file}")
         save_to_netcdf_to_s3(dataset, save_file)
-
 
 
 def save_dataset_to_zarr(
@@ -566,6 +565,7 @@ def create_markdown_table(table_info: dict, index_name: str = "Id") -> str:
 
     return md_str
 
+
 def save_to_netcdf_to_s3(dataset: xr.Dataset, filename: str):
     """Save xarray to netcdf in s3
     1. Save in temp local dir
@@ -581,6 +581,7 @@ def save_to_netcdf_to_s3(dataset: xr.Dataset, filename: str):
         # save to s3
         filesystem = fsspec.open(filename).fs
         filesystem.put(path, filename)
+
 
 # Cell
 def set_up_logging(

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -395,7 +395,8 @@ def save_native_to_netcdf(
                 "time", "y_geostationary", "x_geostationary", "variable"
             )
             hrv_dataset = hrv_dataarray.to_dataset(name="data")
-            now_time = hrv_dataset["time"].strftime("%Y%m%d%H%M")
+            hrv_dataset.attrs = {}
+            now_time = pd.Timestamp(hrv_dataset["time"].values[0]).strftime("%Y%m%d%H%M")
             save_file = os.path.join(save_dir, f"hrv_{now_time}.nc")
             logger.info(f"Saving HRV netcdf in {save_file}")
             save_to_netcdf_to_s3(hrv_dataset, save_file)
@@ -423,7 +424,8 @@ def save_native_to_netcdf(
         dataarray = scaler.rescale(dataarray)
         dataarray = dataarray.transpose("time", "y_geostationary", "x_geostationary", "variable")
         dataset = dataarray.to_dataset(name="data")
-        now_time = dataset["time"].strftime("%Y%m%d%H%M")
+        dataset.attrs = {}
+        now_time = pd.Timestamp(dataset["time"].values[0]).strftime("%Y%m%d%H%M")
         save_file = os.path.join(save_dir, f"{now_time}.nc")
         logger.info(f"Saving non-HRV netcdf in {save_file}")
         save_to_netcdf_to_s3(dataset, save_file)
@@ -573,15 +575,35 @@ def save_to_netcdf_to_s3(dataset: xr.Dataset, filename: str):
     :param dataset: The Xarray Dataset to be save
     :param filename: The s3 filname
     """
+    print(dataset)
     with tempfile.TemporaryDirectory() as dir:
         # save locally
         path = f"{dir}/temp.netcdf"
-        dataset.to_netcdf(path=path, mode="w", engine="h5netcdf")
+        dataset.to_netcdf(path=path, mode="w", engine="h5netcdf", invalid_netcdf = True)
 
         # save to s3
         filesystem = fsspec.open(filename).fs
         filesystem.put(path, filename)
 
+def filter_dataset_ids_on_current_files(datasets, save_dir):
+    from satip.eumetsat import eumetsat_filename_to_datetime
+    ids = [dataset["id"] for dataset in datasets]
+    filesystem = fsspec.open(save_dir).fs
+    finished_files = filesystem.glob("*.nc")
+    datetimes = [pd.Timestamp(eumetsat_filename_to_datetime(idx)).round("5 min") for idx in ids]
+    finished_datetimes = []
+    for date in finished_files:
+        finished_datetimes.append(pd.to_datetime(date.split(".nc")[0], format="%Y%m%d%H%M", errors='ignore'))
+    idx_to_remove = []
+    for idx, date in enumerate(datetimes):
+        if date in finished_datetimes:
+            idx_to_remove.append(idx)
+
+    indices = sorted(idx_to_remove, reverse=True)
+    for idx in indices:
+        if idx < len(datasets):
+            datasets.pop(idx)
+    return datasets
 
 # Cell
 def set_up_logging(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,28 +4,23 @@ Tests for the consumer app
 import glob
 import os
 
-import pandas as pd
+import tempfile
+from click.testing import CliRunner
 
-from satip.eumetsat import DownloadManager
-from satip.utils import save_native_to_netcdf
+from satip.app import run
 
+runner = CliRunner()
 
-def test_saving_netcdf():
-    """Tests the same saving as in run.py"""
+def test_save_to_netcdf():
     user_key = os.environ.get("EUMETSAT_USER_KEY")
     user_secret = os.environ.get("EUMETSAT_USER_SECRET")
-    download_manager = DownloadManager(
-        user_key=user_key, user_secret=user_secret, data_dir=os.getcwd()
-    )
-    download_manager.download_date_range(
-        start_date=(pd.Timestamp.now() - pd.Timedelta("1 hour")).strftime("%Y-%m-%d-%H-%M-%S"),
-        end_date=pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"),
-    )
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        response = runner.invoke(
+            run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname]
+            )
+        native_files = list(glob.glob(os.path.join(tmpdirname, "*.nat")))
+        assert len(native_files) > 0
+        assert os.path.exists(os.path.join(tmpdirname, "latest.nc"))
+        assert os.path.exists(os.path.join(tmpdirname, "hrv_latest.nc"))
 
-    # 2. Load grib files to one Xarray Dataset
-    native_files = list(glob.glob(os.path.join(os.getcwd(), "*.nat")))
-    # data = datahub.load_all_files()
-    save_native_to_netcdf(native_files, save_dir=os.getcwd())
-    assert len(native_files) > 0
-    assert os.path.exists(os.path.join(os.getcwd(), "latest.nc"))
-    assert os.path.exists(os.path.join(os.getcwd(), "hrv_latest.nc"))
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,10 +16,8 @@ def test_save_to_netcdf():
     user_key = os.environ.get("EUMETSAT_USER_KEY")
     user_secret = os.environ.get("EUMETSAT_USER_SECRET")
     with tempfile.TemporaryDirectory() as tmpdirname:
-        response = runner.invoke(
+        runner.invoke(
             run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname]
         )
-        native_files = list(glob.glob(os.path.join(tmpdirname, "*.nat")))
+        native_files = list(glob.glob(os.path.join(tmpdirname, "*.nc")))
         assert len(native_files) > 0
-        assert os.path.exists(os.path.join(tmpdirname, "latest.nc"))
-        assert os.path.exists(os.path.join(tmpdirname, "hrv_latest.nc"))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,13 +3,14 @@ Tests for the consumer app
 """
 import glob
 import os
-
 import tempfile
+
 from click.testing import CliRunner
 
 from satip.app import run
 
 runner = CliRunner()
+
 
 def test_save_to_netcdf():
     user_key = os.environ.get("EUMETSAT_USER_KEY")
@@ -17,10 +18,8 @@ def test_save_to_netcdf():
     with tempfile.TemporaryDirectory() as tmpdirname:
         response = runner.invoke(
             run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname]
-            )
+        )
         native_files = list(glob.glob(os.path.join(tmpdirname, "*.nat")))
         assert len(native_files) > 0
         assert os.path.exists(os.path.join(tmpdirname, "latest.nc"))
         assert os.path.exists(os.path.join(tmpdirname, "hrv_latest.nc"))
-
-


### PR DESCRIPTION
# Pull Request

## Description

The pods in AWS keep running out of memory, trying to process the whole area in multiple timesteps, so this makes each file its own NetCDF file that is saved instead to make it simpler and lower memory usage.

Fixes #86 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
