### PR TITLE
Do not rescale data by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ python satip/get_raw_eumetsat_data.py --user-key=<EUMETSAT API Key> --user-secre
 `scripts/convert_native_to_zarr.py` converts EUMETSAT `.nat` files to Zarr datasets, using very mild lossy [JPEG-XL](https://en.wikipedia.org/wiki/JPEG_XL) compression. (JPEG-XL is the "new kid on the block" of image compression algorithms). JPEG-XL makes the files about a quarter the size of the equivalent `bz2` compressed files, whilst the images are visually indistinguishable. JPEG-XL cannot represent NaNs so NaNs. JPEG-XL understands float32 values in the range `[0, 1]`. NaNs are encoded as the value `0.025`. All "real" values are in the range `[0.075, 1]`. We leave a gap between "NaNs" and "real values" because there is very slight "ringing" around areas of constant value (see [this comment for more details](https://github.com/openclimatefix/Satip/issues/67#issuecomment-1036456502)). Use `satip.jpeg_xl_float_with_nans.JpegXlFloatWithNaNs` to decode the satellite data. This class will reconstruct the NaNs and rescale the data to the range `[0, 1]`.
 
 
+## Running in Production
+
+The live service uses `app.py` as the entrypoint for running the live data download for OCF's forecasting service, and has a few configuration options.
+
+`--api-key` is the EUMETSAT API key
+
+`--api-secret` is the EUMETSAT API secret
+
+`--save-dir` is the top level directory to save the output files, a `latest` subfolder will be added to that directory to contain the latest data
+
+`--history` is the amount of history timesteps to use in the `latest.zarr` files
+
+`--db-url` is the URL to the database to save to when a run has finished
+
+`--use-rescaler` tells whether to rescale the satellite data to between 0 and 1 or not when saving to disk. Primarily used as backwards compatibility for the current production models, all new training and production Zarrs should use the rescaled data.
+
 ## Testing
 
 To run tests, simply run ```pytest .``` from the root of the repository. To generate the test plots, run ```python scripts/generate_test_plots.py```.

--- a/README.md
+++ b/README.md
@@ -72,19 +72,19 @@ python satip/get_raw_eumetsat_data.py --user-key=<EUMETSAT API Key> --user-secre
 
 ## Running in Production
 
-The live service uses `app.py` as the entrypoint for running the live data download for OCF's forecasting service, and has a few configuration options.
+The live service uses `app.py` as the entrypoint for running the live data download for OCF's forecasting service, and has a few configuration options, configurable by command line argument or environment variable.
 
-`--api-key` is the EUMETSAT API key
+`--api-key` or `API_KEY` is the EUMETSAT API key
 
-`--api-secret` is the EUMETSAT API secret
+`--api-secret` or `API_SECRET` is the EUMETSAT API secret
 
-`--save-dir` is the top level directory to save the output files, a `latest` subfolder will be added to that directory to contain the latest data
+`--save-dir` or `SAVE_DIR` is the top level directory to save the output files, a `latest` subfolder will be added to that directory to contain the latest data
 
-`--history` is the amount of history timesteps to use in the `latest.zarr` files
+`--history` or `HISTORY` is the amount of history timesteps to use in the `latest.zarr` files
 
-`--db-url` is the URL to the database to save to when a run has finished
+`--db-url` or `DB_URL` is the URL to the database to save to when a run has finished
 
-`--use-rescaler` tells whether to rescale the satellite data to between 0 and 1 or not when saving to disk. Primarily used as backwards compatibility for the current production models, all new training and production Zarrs should use the rescaled data.
+`--use-rescaler` or `USE_RESCALER` tells whether to rescale the satellite data to between 0 and 1 or not when saving to disk. Primarily used as backwards compatibility for the current production models, all new training and production Zarrs should use the rescaled data.
 
 ## Testing
 

--- a/satip/app.py
+++ b/satip/app.py
@@ -61,7 +61,14 @@ logging.getLogger(__name__).setLevel(logging.INFO)
     help="Database to save when this has run",
     type=click.STRING,
 )
-def run(api_key, api_secret, save_dir, history, db_url: Optional[str] = None):
+@click.option(
+    "--use-rescaler",
+    default=False,
+    envvar="USE_RESCALER",
+    help="Whether to rescale data to between 0 and 1 or not",
+    type=click.BOOL,
+)
+def run(api_key, api_secret, save_dir, history, db_url: Optional[str] = None, use_rescaler: bool = False):
     """Run main application
 
     Args:
@@ -70,6 +77,7 @@ def run(api_key, api_secret, save_dir, history, db_url: Optional[str] = None):
         save_dir: Save directory
         history: History time
         db_url: URL of database
+        use_rescaler: Rescale data to between 0 and 1 or not
     """
 
     logger.info(f'Running application and saving to "{save_dir}"')
@@ -92,7 +100,7 @@ def run(api_key, api_secret, save_dir, history, db_url: Optional[str] = None):
         native_files = list(glob.glob(os.path.join(tmpdir, "*.nat")))
 
         # Save to S3
-        save_native_to_netcdf(native_files, save_dir=save_dir)
+        save_native_to_netcdf(native_files, save_dir=save_dir, use_rescaler=use_rescaler)
 
         # Move around files into and out of latest
         move_older_files_to_different_location(

--- a/satip/app.py
+++ b/satip/app.py
@@ -68,7 +68,9 @@ logging.getLogger(__name__).setLevel(logging.INFO)
     help="Whether to rescale data to between 0 and 1 or not",
     type=click.BOOL,
 )
-def run(api_key, api_secret, save_dir, history, db_url: Optional[str] = None, use_rescaler: bool = False):
+def run(
+    api_key, api_secret, save_dir, history, db_url: Optional[str] = None, use_rescaler: bool = False
+):
     """Run main application
 
     Args:

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -318,7 +318,7 @@ def save_native_to_netcdf(
         "WV_073",
     ],
     save_dir: str = "./",
-        use_rescaler: bool = False
+    use_rescaler: bool = False,
 ) -> None:
     """
     Saves native files to NetCDF for consumer
@@ -438,21 +438,23 @@ def save_native_to_netcdf(
         if use_rescaler:
             dataarray = scaler.rescale(dataarray)
         else:
-            dataarray = dataarray.reindex({"variable": [
-                "IR_016",
-                "IR_039",
-                "IR_087",
-                "IR_097",
-                "IR_108",
-                "IR_120",
-                "IR_134",
-                "VIS006",
-                "VIS008",
-                "WV_062",
-                "WV_073",
-            ]}).transpose(
-                "time", "y_geostationary", "x_geostationary", "variable"
-            )
+            dataarray = dataarray.reindex(
+                {
+                    "variable": [
+                        "IR_016",
+                        "IR_039",
+                        "IR_087",
+                        "IR_097",
+                        "IR_108",
+                        "IR_120",
+                        "IR_134",
+                        "VIS006",
+                        "VIS008",
+                        "WV_062",
+                        "WV_073",
+                    ]
+                }
+            ).transpose("time", "y_geostationary", "x_geostationary", "variable")
             dataarray = dataarray.astype(np.float32)
         dataarray = dataarray.transpose("time", "y_geostationary", "x_geostationary", "variable")
         dataset = dataarray.to_dataset(name="data")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,17 +17,38 @@ def test_save_to_netcdf():  # noqa 103
     user_secret = os.environ.get("EUMETSAT_USER_SECRET")
     with tempfile.TemporaryDirectory() as tmpdirname:
         runner.invoke(
-            run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname, "--use-rescaler", False]
+            run,
+            [
+                "--api-key",
+                user_key,
+                "--api-secret",
+                user_secret,
+                "--save-dir",
+                tmpdirname,
+                "--use-rescaler",
+                False,
+            ],
         )
         native_files = list(glob.glob(os.path.join(tmpdirname, "*.zarr.zip")))
         assert len(native_files) > 0
+
 
 def test_save_to_netcdf_rescaled():  # noqa 103
     user_key = os.environ.get("EUMETSAT_USER_KEY")
     user_secret = os.environ.get("EUMETSAT_USER_SECRET")
     with tempfile.TemporaryDirectory() as tmpdirname:
         runner.invoke(
-            run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname, "--use-rescaler", True]
+            run,
+            [
+                "--api-key",
+                user_key,
+                "--api-secret",
+                user_secret,
+                "--save-dir",
+                tmpdirname,
+                "--use-rescaler",
+                True,
+            ],
         )
         native_files = list(glob.glob(os.path.join(tmpdirname, "*.zarr.zip")))
         assert len(native_files) > 0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,7 +17,17 @@ def test_save_to_netcdf():  # noqa 103
     user_secret = os.environ.get("EUMETSAT_USER_SECRET")
     with tempfile.TemporaryDirectory() as tmpdirname:
         runner.invoke(
-            run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname]
+            run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname, "--use-rescaler", False]
+        )
+        native_files = list(glob.glob(os.path.join(tmpdirname, "*.zarr.zip")))
+        assert len(native_files) > 0
+
+def test_save_to_netcdf_rescaled():  # noqa 103
+    user_key = os.environ.get("EUMETSAT_USER_KEY")
+    user_secret = os.environ.get("EUMETSAT_USER_SECRET")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        runner.invoke(
+            run, ["--api-key", user_key, "--api-secret", user_secret, "--save-dir", tmpdirname, "--use-rescaler", True]
         )
         native_files = list(glob.glob(os.path.join(tmpdirname, "*.zarr.zip")))
         assert len(native_files) > 0


### PR DESCRIPTION
# Pull Request

## Description

To keep the live data matching the v15 dataset the models were trained on as much as possible, this gives an option to rescale the data or not, by default leaving the dataast as the native values.

Fixes #112 

## How Has This Been Tested?

Unit tests

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
