### PR TITLE
Add back old compression to match v15 dataset

### DIFF
--- a/satip/utils.py
+++ b/satip/utils.py
@@ -301,7 +301,9 @@ def convert_scene_to_dataarray(
     return dataarray
 
 
-def do_old_rescaling(dataarray: xr.DataArray, mins: np.ndarray, maxs: np.ndarray, variable_order: list) -> xr.DataArray:
+def do_old_rescaling(
+    dataarray: xr.DataArray, mins: np.ndarray, maxs: np.ndarray, variable_order: list
+) -> xr.DataArray:
     """
     Performs old version of cocmpression, same as v15 dataset
 
@@ -317,7 +319,7 @@ def do_old_rescaling(dataarray: xr.DataArray, mins: np.ndarray, maxs: np.ndarray
     ataarray = dataarray.reindex({"variable": variable_order}).transpose(
         "time", "y_geostationary", "x_geostationary", "variable"
     )
-    upper_bound = (2 ** 10) - 1
+    upper_bound = (2**10) - 1
     new_max = maxs - mins
 
     dataarray -= mins
@@ -426,7 +428,12 @@ def save_native_to_netcdf(
             if use_rescaler:
                 hrv_dataarray = hrv_scaler.rescale(hrv_dataarray)
             else:
-                hrv_dataarray = do_old_rescaling(hrv_dataarray, variable_order=["HRV"], maxs=np.array([103.90016]), mins=np.array([-1.2278595]))
+                hrv_dataarray = do_old_rescaling(
+                    hrv_dataarray,
+                    variable_order=["HRV"],
+                    maxs=np.array([103.90016]),
+                    mins=np.array([-1.2278595]),
+                )
             hrv_dataarray = hrv_dataarray.transpose(
                 "time", "y_geostationary", "x_geostationary", "variable"
             )
@@ -461,49 +468,52 @@ def save_native_to_netcdf(
         if use_rescaler:
             dataarray = scaler.rescale(dataarray)
         else:
-            dataarray = do_old_rescaling(dataarray, mins=np.array(
-                [
-                    -2.5118103,
-                    -64.83977,
-                    63.404694,
-                    2.844452,
-                    199.10002,
-                    -17.254883,
-                    -26.29155,
-                    -1.1009827,
-                    -2.4184198,
-                    199.57048,
-                    198.95093,
-                ]
-            ),
-                                         maxs=np.array(
-                                             [
-                                                 69.60857,
-                                                 339.15588,
-                                                 340.26526,
-                                                 317.86752,
-                                                 313.2767,
-                                                 315.99194,
-                                                 274.82297,
-                                                 93.786545,
-                                                 101.34922,
-                                                 249.91806,
-                                                 286.96323,
-                                             ]
-                                         ),
-                                         variable_order=[
-                                             "IR_016",
-                                             "IR_039",
-                                             "IR_087",
-                                             "IR_097",
-                                             "IR_108",
-                                             "IR_120",
-                                             "IR_134",
-                                             "VIS006",
-                                             "VIS008",
-                                             "WV_062",
-                                             "WV_073",
-                                         ],)
+            dataarray = do_old_rescaling(
+                dataarray,
+                mins=np.array(
+                    [
+                        -2.5118103,
+                        -64.83977,
+                        63.404694,
+                        2.844452,
+                        199.10002,
+                        -17.254883,
+                        -26.29155,
+                        -1.1009827,
+                        -2.4184198,
+                        199.57048,
+                        198.95093,
+                    ]
+                ),
+                maxs=np.array(
+                    [
+                        69.60857,
+                        339.15588,
+                        340.26526,
+                        317.86752,
+                        313.2767,
+                        315.99194,
+                        274.82297,
+                        93.786545,
+                        101.34922,
+                        249.91806,
+                        286.96323,
+                    ]
+                ),
+                variable_order=[
+                    "IR_016",
+                    "IR_039",
+                    "IR_087",
+                    "IR_097",
+                    "IR_108",
+                    "IR_120",
+                    "IR_134",
+                    "VIS006",
+                    "VIS008",
+                    "WV_062",
+                    "WV_073",
+                ],
+            )
         dataarray = dataarray.transpose("time", "y_geostationary", "x_geostationary", "variable")
         dataset = dataarray.to_dataset(name="data")
         dataset.attrs.update(attrs)

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -316,7 +316,7 @@ def do_old_rescaling(
     Returns:
         Xarray DataArray
     """
-    ataarray = dataarray.reindex({"variable": variable_order}).transpose(
+    dataarray = dataarray.reindex({"variable": variable_order}).transpose(
         "time", "y_geostationary", "x_geostationary", "variable"
     )
     upper_bound = (2**10) - 1

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -301,7 +301,7 @@ def convert_scene_to_dataarray(
     return dataarray
 
 
-def do_old_rescaling(
+def do_v15_rescaling(
     dataarray: xr.DataArray, mins: np.ndarray, maxs: np.ndarray, variable_order: list
 ) -> xr.DataArray:
     """
@@ -428,7 +428,7 @@ def save_native_to_netcdf(
             if use_rescaler:
                 hrv_dataarray = hrv_scaler.rescale(hrv_dataarray)
             else:
-                hrv_dataarray = do_old_rescaling(
+                hrv_dataarray = do_v15_rescaling(
                     hrv_dataarray,
                     variable_order=["HRV"],
                     maxs=np.array([103.90016]),
@@ -468,7 +468,7 @@ def save_native_to_netcdf(
         if use_rescaler:
             dataarray = scaler.rescale(dataarray)
         else:
-            dataarray = do_old_rescaling(
+            dataarray = do_v15_rescaling(
                 dataarray,
                 mins=np.array(
                     [

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -301,6 +301,32 @@ def convert_scene_to_dataarray(
     return dataarray
 
 
+def do_old_rescaling(dataarray: xr.DataArray, mins: np.ndarray, maxs: np.ndarray, variable_order: list) -> xr.DataArray:
+    """
+    Performs old version of cocmpression, same as v15 dataset
+
+    Args:
+        dataarray: Input DataArray
+        mins: Min values per channel
+        maxs: Max values per channel
+        variable_order: Channel ordering
+
+    Returns:
+        Xarray DataArray
+    """
+    ataarray = dataarray.reindex({"variable": variable_order}).transpose(
+        "time", "y_geostationary", "x_geostationary", "variable"
+    )
+    upper_bound = (2 ** 10) - 1
+    new_max = maxs - mins
+
+    dataarray -= mins
+    dataarray /= new_max
+    dataarray *= upper_bound
+    dataarray = dataarray.round().clip(min=0, max=upper_bound).astype(np.int16)
+    return dataarray
+
+
 def save_native_to_netcdf(
     list_of_native_files: list,
     bands: list = [
@@ -400,10 +426,7 @@ def save_native_to_netcdf(
             if use_rescaler:
                 hrv_dataarray = hrv_scaler.rescale(hrv_dataarray)
             else:
-                hrv_dataarray = hrv_dataarray.reindex({"variable": ["HRV"]}).transpose(
-                    "time", "y_geostationary", "x_geostationary", "variable"
-                )
-                hrv_dataarray = hrv_dataarray.astype(np.float32)
+                hrv_dataarray = do_old_rescaling(hrv_dataarray, variable_order=["HRV"], maxs=np.array([103.90016]), mins=np.array([-1.2278595]))
             hrv_dataarray = hrv_dataarray.transpose(
                 "time", "y_geostationary", "x_geostationary", "variable"
             )
@@ -438,24 +461,49 @@ def save_native_to_netcdf(
         if use_rescaler:
             dataarray = scaler.rescale(dataarray)
         else:
-            dataarray = dataarray.reindex(
-                {
-                    "variable": [
-                        "IR_016",
-                        "IR_039",
-                        "IR_087",
-                        "IR_097",
-                        "IR_108",
-                        "IR_120",
-                        "IR_134",
-                        "VIS006",
-                        "VIS008",
-                        "WV_062",
-                        "WV_073",
-                    ]
-                }
-            ).transpose("time", "y_geostationary", "x_geostationary", "variable")
-            dataarray = dataarray.astype(np.float32)
+            dataarray = do_old_rescaling(dataarray, mins=np.array(
+                [
+                    -2.5118103,
+                    -64.83977,
+                    63.404694,
+                    2.844452,
+                    199.10002,
+                    -17.254883,
+                    -26.29155,
+                    -1.1009827,
+                    -2.4184198,
+                    199.57048,
+                    198.95093,
+                ]
+            ),
+                                         maxs=np.array(
+                                             [
+                                                 69.60857,
+                                                 339.15588,
+                                                 340.26526,
+                                                 317.86752,
+                                                 313.2767,
+                                                 315.99194,
+                                                 274.82297,
+                                                 93.786545,
+                                                 101.34922,
+                                                 249.91806,
+                                                 286.96323,
+                                             ]
+                                         ),
+                                         variable_order=[
+                                             "IR_016",
+                                             "IR_039",
+                                             "IR_087",
+                                             "IR_097",
+                                             "IR_108",
+                                             "IR_120",
+                                             "IR_134",
+                                             "VIS006",
+                                             "VIS008",
+                                             "WV_062",
+                                             "WV_073",
+                                         ],)
         dataarray = dataarray.transpose("time", "y_geostationary", "x_geostationary", "variable")
         dataset = dataarray.to_dataset(name="data")
         dataset.attrs.update(attrs)


### PR DESCRIPTION
# Pull Request

## Description

Adds back the exact same compression as used for v15 dataset, I think, which should fix the issue of live not matching training data

Fixes #112 

## How Has This Been Tested?

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
