### PR TITLE
Add 15 minutely fallback option

### DIFF
--- a/satip/app.py
+++ b/satip/app.py
@@ -93,6 +93,9 @@ def run(
             start_date=start_date.strftime("%Y-%m-%d-%H-%M-%S"),
             end_date=pd.Timestamp.utcnow().strftime("%Y-%m-%d-%H-%M-%S"),
         )
+        # Check if any RSS imagery is available, if not, fall back to 15 minutely data
+        if len(datasets) == 0:
+            logger.info("No RSS Imagery available, falling back to 15-minutely data")
         # Filter out ones that already exist
         datasets = filter_dataset_ids_on_current_files(datasets, save_dir)
         logger.info(f"Files to download after filtering: {len(datasets)}")

--- a/satip/app.py
+++ b/satip/app.py
@@ -100,7 +100,7 @@ def run(
             datasets = download_manager.identify_available_datasets(
                 start_date=start_date.strftime("%Y-%m-%d-%H-%M-%S"),
                 end_date=pd.Timestamp.utcnow().strftime("%Y-%m-%d-%H-%M-%S"),
-                product_id="EO:EUM:DAT:MSG:HRSEVIRI"
+                product_id="EO:EUM:DAT:MSG:HRSEVIRI",
             )
             using_backup = True
         # Filter out ones that already exist
@@ -116,7 +116,9 @@ def run(
         native_files = list(glob.glob(os.path.join(tmpdir, "*.nat")))
 
         # Save to S3
-        save_native_to_zarr(native_files, save_dir=save_dir, use_rescaler=use_rescaler, using_backup=using_backup)
+        save_native_to_zarr(
+            native_files, save_dir=save_dir, use_rescaler=use_rescaler, using_backup=using_backup
+        )
 
         # Move around files into and out of latest
         move_older_files_to_different_location(

--- a/satip/app.py
+++ b/satip/app.py
@@ -16,7 +16,7 @@ from satip.utils import (
     collate_files_into_latest,
     filter_dataset_ids_on_current_files,
     move_older_files_to_different_location,
-    save_native_to_netcdf,
+    save_native_to_zarr,
 )
 
 logging.basicConfig(format="%(asctime)s %(name)s %(levelname)s:%(message)s")
@@ -116,7 +116,7 @@ def run(
         native_files = list(glob.glob(os.path.join(tmpdir, "*.nat")))
 
         # Save to S3
-        save_native_to_netcdf(native_files, save_dir=save_dir, use_rescaler=use_rescaler)
+        save_native_to_zarr(native_files, save_dir=save_dir, use_rescaler=use_rescaler, using_backup=using_backup)
 
         # Move around files into and out of latest
         move_older_files_to_different_location(
@@ -124,7 +124,7 @@ def run(
         )
 
         # Collate files into single NetCDF file
-        collate_files_into_latest(save_dir=save_dir)
+        collate_files_into_latest(save_dir=save_dir, using_backup=using_backup)
 
     # 4. update table to show when this data has been pulled
     if db_url is not None:

--- a/satip/app.py
+++ b/satip/app.py
@@ -83,6 +83,7 @@ def run(
     """
 
     logger.info(f'Running application and saving to "{save_dir}"')
+    using_backup = False
     # 1. Get data from API, download native files
     with tempfile.TemporaryDirectory() as tmpdir:
         download_manager = DownloadManager(
@@ -96,6 +97,12 @@ def run(
         # Check if any RSS imagery is available, if not, fall back to 15 minutely data
         if len(datasets) == 0:
             logger.info("No RSS Imagery available, falling back to 15-minutely data")
+            datasets = download_manager.identify_available_datasets(
+                start_date=start_date.strftime("%Y-%m-%d-%H-%M-%S"),
+                end_date=pd.Timestamp.utcnow().strftime("%Y-%m-%d-%H-%M-%S"),
+                product_id="EO:EUM:DAT:MSG:HRSEVIRI"
+            )
+            using_backup = True
         # Filter out ones that already exist
         datasets = filter_dataset_ids_on_current_files(datasets, save_dir)
         logger.info(f"Files to download after filtering: {len(datasets)}")

--- a/satip/download.py
+++ b/satip/download.py
@@ -52,6 +52,7 @@ NATIVE_FILESIZE_MB = 102.210123
 CLOUD_FILESIZE_MB = 3.445185
 RSS_ID = "EO:EUM:DAT:MSG:MSG15-RSS"
 CLOUD_ID = "EO:EUM:DAT:MSG:RSS-CLM"
+SEVIRI_ID = "EO:EUM:DAT:MSG:HRSEVIRI"
 
 
 def download_eumetsat_data(
@@ -116,6 +117,8 @@ def download_eumetsat_data(
         products_to_use.append(RSS_ID)
     if "cloud" in product:
         products_to_use.append(CLOUD_ID)
+    if "seviri" in product:
+        products_to_use.append(SEVIRI_ID)
 
     for product_id in products_to_use:
         # Do this to clear out any partially downloaded days

--- a/satip/intermediate.py
+++ b/satip/intermediate.py
@@ -82,6 +82,7 @@ def split_per_month(
             print(month_zarr_path)
             zarr_exists = os.path.exists(month_zarr_path)
             if not zarr_exists:
+                print(f"Making Zarr: {month_zarr_path}")
                 # Inital zarr path before then appending
                 compressed_native_files = sorted(list(Path(month_directory).rglob("*.bz2")))
                 if len(compressed_native_files) == 0:

--- a/satip/intermediate.py
+++ b/satip/intermediate.py
@@ -79,6 +79,7 @@ def split_per_month(
             dirs.append(month_directory)
             zarrs.append(month_zarr_path)
             hrv_zarrs.append(hrv_month_zarr_path)
+            print(month_zarr_path)
             zarr_exists = os.path.exists(month_zarr_path)
             if not zarr_exists:
                 # Inital zarr path before then appending
@@ -106,10 +107,8 @@ def split_per_month(
                     y_size_per_chunk=1536,
                     timesteps_per_chunk=temporal_chunk_size,
                 )
-    print(dirs)
-    print(zarrs)
-    pool = multiprocessing.Pool(processes=os.cpu_count())
-    for _ in tqdm(
+    pool = multiprocessing.Pool(processes=3)
+    for d in tqdm(
         pool.imap_unordered(
             _wrapper_create_or_update_xarr_with_native_files,
             zip(
@@ -123,7 +122,7 @@ def split_per_month(
             ),
         )
     ):
-        print("Month done")
+        print(f"Month {d} done")
 
 
 def _wrapper_create_or_update_xarr_with_native_files(args):
@@ -281,7 +280,7 @@ def create_or_update_zarr_with_native_files(
     region: str,
     spatial_chunk_size: int = 256,
     temporal_chunk_size: int = 1,
-) -> None:
+) -> str:
     """
     Creates or updates a zarr file with satellite native files
 
@@ -345,6 +344,7 @@ def create_or_update_zarr_with_native_files(
             del hrv_dataarray
         except Exception as e:
             print(f"Failed with Exception with {e}")
+    return directory
 
 
 # TODO: Not used in the repo, remove?

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -716,7 +716,7 @@ def filter_dataset_ids_on_current_files(datasets: list, save_dir: str) -> list:
     for date in finished_files:
         finished_datetimes.append(
             pd.to_datetime(
-                date.split(".zarr.zip")[0].split("/")[-1], format="%Y%m%d%H%M", errors="ignore"
+                date.replace("15_", "").split(".zarr.zip")[0].split("/")[-1], format="%Y%m%d%H%M", errors="ignore"
             )
         )
     if len(finished_datetimes) > 0:

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -347,7 +347,7 @@ def save_native_to_zarr(
     ],
     save_dir: str = "./",
     use_rescaler: bool = False,
-        using_backup: bool = False
+    using_backup: bool = False,
 ) -> None:
     """
     Saves native files to NetCDF for consumer
@@ -442,7 +442,9 @@ def save_native_to_zarr(
             hrv_dataset = hrv_dataarray.to_dataset(name="data")
             hrv_dataset.attrs.update(attrs)
             now_time = pd.Timestamp(hrv_dataset["time"].values[0]).strftime("%Y%m%d%H%M")
-            save_file = os.path.join(save_dir, f"{'15_' if using_backup else ''}hrv_{now_time}.zarr.zip")
+            save_file = os.path.join(
+                save_dir, f"{'15_' if using_backup else ''}hrv_{now_time}.zarr.zip"
+            )
             logger.info(f"Saving HRV netcdf in {save_file}")
             save_to_zarr_to_s3(hrv_dataset, save_file)
 
@@ -816,7 +818,9 @@ def collate_files_into_latest(save_dir: str, using_backup: bool = False):
 
     """
     filesystem = fsspec.open(save_dir).fs
-    hrv_files = list(filesystem.glob(f"{save_dir}/latest/{'15_' if using_backup else ''}hrv_2*.zarr.zip"))
+    hrv_files = list(
+        filesystem.glob(f"{save_dir}/latest/{'15_' if using_backup else ''}hrv_2*.zarr.zip")
+    )
     if not hrv_files:  # Empty set of files, don't do anything
         return
     # Add S3 to beginning of each URL
@@ -825,17 +829,25 @@ def collate_files_into_latest(save_dir: str, using_backup: bool = False):
         hrv_files, concat_dim="time", combine="nested", engine="zarr"
     ).sortby("time")
     save_to_zarr_to_s3(dataset, f"{save_dir}/latest/hrv_tmp.zarr.zip")
-    nonhrv_files = list(filesystem.glob(f"{save_dir}/latest/{'15_' if using_backup else ''}2*.zarr.zip"))
+    nonhrv_files = list(
+        filesystem.glob(f"{save_dir}/latest/{'15_' if using_backup else ''}2*.zarr.zip")
+    )
     nonhrv_files = ["zip:///::s3://" + str(f) for f in nonhrv_files]
     o_dataset = xr.open_mfdataset(
         nonhrv_files, concat_dim="time", combine="nested", engine="zarr"
     ).sortby("time")
     save_to_zarr_to_s3(o_dataset, f"{save_dir}/latest/tmp.zarr.zip")
     filesystem = fsspec.open(f"{save_dir}/latest/hrv_tmp.zarr.zip").fs
-    filesystem.mv(f"{save_dir}/latest/hrv_tmp.zarr.zip", f"{save_dir}/latest/{'15_' if using_backup else ''}hrv_latest.zarr.zip")
+    filesystem.mv(
+        f"{save_dir}/latest/hrv_tmp.zarr.zip",
+        f"{save_dir}/latest/{'15_' if using_backup else ''}hrv_latest.zarr.zip",
+    )
     logger.info(f"Collating HRV into {save_dir}/latest/hrv_latest.zarr.zip")
     filesystem = fsspec.open(f"{save_dir}/latest/tmp.zarr.zip").fs
-    filesystem.mv(f"{save_dir}/latest/tmp.zarr.zip", f"{save_dir}/latest/{'15_' if using_backup else ''}latest.zarr.zip")
+    filesystem.mv(
+        f"{save_dir}/latest/tmp.zarr.zip",
+        f"{save_dir}/latest/{'15_' if using_backup else ''}latest.zarr.zip",
+    )
     logger.info(f"Collating non-HRV into {save_dir}/latest/latest.zarr.zip")
 
 

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -716,7 +716,9 @@ def filter_dataset_ids_on_current_files(datasets: list, save_dir: str) -> list:
     for date in finished_files:
         finished_datetimes.append(
             pd.to_datetime(
-                date.replace("15_", "").split(".zarr.zip")[0].split("/")[-1], format="%Y%m%d%H%M", errors="ignore"
+                date.replace("15_", "").split(".zarr.zip")[0].split("/")[-1],
+                format="%Y%m%d%H%M",
+                errors="ignore",
             )
         )
     if len(finished_datetimes) > 0:

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -829,7 +829,7 @@ def collate_files_into_latest(save_dir: str, using_backup: bool = False):
     hrv_files = ["zip:///::s3://" + str(f) for f in hrv_files]
     dataset = xr.open_mfdataset(
         hrv_files, concat_dim="time", combine="nested", engine="zarr"
-    ).sortby("time")
+    ).sortby("time").drop_duplicates("time")
     save_to_zarr_to_s3(dataset, f"{save_dir}/latest/hrv_tmp.zarr.zip")
     nonhrv_files = list(
         filesystem.glob(f"{save_dir}/latest/{'15_' if using_backup else ''}2*.zarr.zip")
@@ -837,7 +837,7 @@ def collate_files_into_latest(save_dir: str, using_backup: bool = False):
     nonhrv_files = ["zip:///::s3://" + str(f) for f in nonhrv_files]
     o_dataset = xr.open_mfdataset(
         nonhrv_files, concat_dim="time", combine="nested", engine="zarr"
-    ).sortby("time")
+    ).sortby("time").drop_duplicates("time")
     save_to_zarr_to_s3(o_dataset, f"{save_dir}/latest/tmp.zarr.zip")
     filesystem = fsspec.open(f"{save_dir}/latest/hrv_tmp.zarr.zip").fs
     filesystem.mv(

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -827,17 +827,21 @@ def collate_files_into_latest(save_dir: str, using_backup: bool = False):
         return
     # Add S3 to beginning of each URL
     hrv_files = ["zip:///::s3://" + str(f) for f in hrv_files]
-    dataset = xr.open_mfdataset(
-        hrv_files, concat_dim="time", combine="nested", engine="zarr"
-    ).sortby("time").drop_duplicates("time")
+    dataset = (
+        xr.open_mfdataset(hrv_files, concat_dim="time", combine="nested", engine="zarr")
+        .sortby("time")
+        .drop_duplicates("time")
+    )
     save_to_zarr_to_s3(dataset, f"{save_dir}/latest/hrv_tmp.zarr.zip")
     nonhrv_files = list(
         filesystem.glob(f"{save_dir}/latest/{'15_' if using_backup else ''}2*.zarr.zip")
     )
     nonhrv_files = ["zip:///::s3://" + str(f) for f in nonhrv_files]
-    o_dataset = xr.open_mfdataset(
-        nonhrv_files, concat_dim="time", combine="nested", engine="zarr"
-    ).sortby("time").drop_duplicates("time")
+    o_dataset = (
+        xr.open_mfdataset(nonhrv_files, concat_dim="time", combine="nested", engine="zarr")
+        .sortby("time")
+        .drop_duplicates("time")
+    )
     save_to_zarr_to_s3(o_dataset, f"{save_dir}/latest/tmp.zarr.zip")
     filesystem = fsspec.open(f"{save_dir}/latest/hrv_tmp.zarr.zip").fs
     filesystem.mv(


### PR DESCRIPTION
# Pull Request

## Description

When RSS imagery isn't available, 15-minutely data should be still available, so try downloading that. Uses a different save name to ensure not accidentally loading 15 minute data when expecting 5 minute data

Fixes #106 

## How Has This Been Tested?

Unit Tests

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
