### PR TITLE
Add cleaning up data tailor if error

### DIFF
--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -493,15 +493,15 @@ class DownloadManager:  # noqa: D205
         product_id = datastore.get_product("EO:EUM:DAT:MSG:HRSEVIRI", dataset_id)
         try:
             self.create_and_download_datatailor_data(
-            dataset_id=product_id,
-            tailor_id=tailor_id,
-            roi=roi,
-            file_format=file_format,
-            projection=projection,
-        )
+                dataset_id=product_id,
+                tailor_id=tailor_id,
+                roi=roi,
+                file_format=file_format,
+                projection=projection,
+            )
         except Exception as e:
-          self.cleanup_datatailor()
-          raise e
+            self.cleanup_datatailor()
+            raise e
 
     def cleanup_datatailor(self):
         """Remove all Data Tailor runs"""

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -491,13 +491,17 @@ class DownloadManager:  # noqa: D205
         token = eumdac.AccessToken(credentials)
         datastore = eumdac.DataStore(token)
         product_id = datastore.get_product("EO:EUM:DAT:MSG:HRSEVIRI", dataset_id)
-        self.create_and_download_datatailor_data(
+        try:
+            self.create_and_download_datatailor_data(
             dataset_id=product_id,
             tailor_id=tailor_id,
             roi=roi,
             file_format=file_format,
             projection=projection,
         )
+        except Exception as e:
+          self.cleanup_datatailor()
+          raise e
 
     def cleanup_datatailor(self):
         """Remove all Data Tailor runs"""

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -511,7 +511,8 @@ class DownloadManager:  # noqa: D205
         for customisation in datatailor.customisations:
             if customisation.status == "DONE" or "FAILED":
                 logger.debug(
-                    f"Delete completed customisation {customisation} from {customisation.creation_time}."
+                    f"Delete completed customisation {customisation} "
+                    "from {customisation.creation_time}."
                 )
                 customisation.delete()
 

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -512,7 +512,7 @@ class DownloadManager:  # noqa: D205
             if customisation.status == "DONE" or "FAILED":
                 logger.debug(
                     f"Delete completed customisation {customisation} "
-                    "from {customisation.creation_time}."
+                    f"from {customisation.creation_time}."
                 )
                 customisation.delete()
 


### PR DESCRIPTION
# Pull Request

## Description

Adds a step if there is any error in the data tailor customization download, it will cleanup all data tailor customizations that are done or failed.

Fixes #

## How Has This Been Tested?

Unit tests

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
