### PR TITLE
Bump python-docker-release workflow to 1.2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   bump-version-python-docker-release:
-    uses: openclimatefix/.github/.github/workflows/python-docker-release.yml@v1.0.0
+    uses: openclimatefix/.github/.github/workflows/python-docker-release.yml@v1.2.0
     secrets:
       token: ${{ secrets.PYPI_API_TOKEN }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
This is to make sure that the new workflow (1.2.0) is backward compatible (unlike 1.1.0).