### PR TITLE
Fix regex for 0000-NA filenames

### DIFF
--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -694,7 +694,7 @@ def eumetsat_filename_to_datetime(inner_tar_name):
         eumetsat_filename_to_datetime(filename)
     """
 
-    p = re.compile(r"^MSG[1234]-SEVI-MSG15-0100-NA-(\d*)\.")
+    p = re.compile(r"^MSG[1234]-SEVI-MSG15-0[01]00-NA-(\d*)\.")
     title_match = p.match(inner_tar_name)
     date_str = title_match.group(1)
     return datetime.datetime.strptime(date_str, "%Y%m%d%H%M%S")

--- a/tests/test_eumetsat.py
+++ b/tests/test_eumetsat.py
@@ -3,8 +3,9 @@ import glob
 import os
 import tempfile
 from datetime import datetime, timezone, timedelta
+import pandas as pd
 
-from satip.eumetsat import DownloadManager
+from satip.eumetsat import DownloadManager, eumetsat_filename_to_datetime
 
 
 def test_download_manager_setup():
@@ -22,7 +23,14 @@ def test_download_manager_setup():
 
 def test_filename_to_datetime():
     """If there were a test here, there would also be a docstring here."""
-    pass
+    filename = "MSG4-SEVI-MSG15-0000-NA-20230814075918.739000000Z-NA"
+    expected_datetime = datetime(2023, 8, 14, 7, 59, 18)
+    actual_datetime = eumetsat_filename_to_datetime(filename)
+    assert actual_datetime == expected_datetime
+    filename = "MSG4-SEVI-MSG15-0100-NA-20230814085917.262000000Z-NA"
+    expected_datetime = datetime(2023, 8, 14, 8, 59, 17)
+    actual_datetime = eumetsat_filename_to_datetime(filename)
+    assert actual_datetime == expected_datetime
 
 
 def test_data_tailor_identify_available_datasets():


### PR DESCRIPTION
# Pull Request

## Description

The regex for getting the datetime from the filename breaks when there is a filename like:
`MSG4-SEVI-MSG15-0000-NA-20230814075918.739000000Z-NA`
where the `0100-NA` string in most RSS imagery is replaced by `0000-NA`. This fixes that

Fixes #

## How Has This Been Tested?

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
