### PR TITLE
correct typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In order to contribute to development or just test-run some scripts, you will ne
 The following command will download the last 2 hours of RSS imagery into NetCDF files at the specified location
 
 ```bash
-python satip/app.py --api-key=<EUMETSAT API Key> --api-secret=<EUMETSAT API Secret> --save-dr="/path/to/saving/files/" --history="2 hours"
+python satip/app.py --api-key=<EUMETSAT API Key> --api-secret=<EUMETSAT API Secret> --save-dir="/path/to/saving/files/" --history="2 hours"
 ```
 
 To download more historical data, the command below will download the native files, compress with bz2, and save into a subdirectory.


### PR DESCRIPTION
# Pull Request

## Description

The readme states to run the following command to download the last 2 hours of RSS imagery, but this fails as save-dr is not a known argument. 

`python satip/app.py --api-key=<EUMETSAT API Key> --api-secret=<EUMETSAT API Secret> --save-dr="/path/to/saving/files/" --history="2 hours"`

Fixes #

From app.py, it looks like this should be `--save-dir`, which I've updated (but might be "--save-dir-native"?). I've updated README.md to correct this

## How Has This Been Tested?

I re-ran the command with --save-dir which was recognised by app.py
- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

N/A

## Checklist:

The default checklist relates to code changes are not applicable as this is a documentation change
- NA My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- NA I have performed a self-review of my code
- NA I have made corresponding changes to the documentation
- NA I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
