### PR TITLE
Add Ability to save to different sinks in app.py #230

### DIFF
--- a/satip/utils.py
+++ b/satip/utils.py
@@ -828,7 +828,7 @@ def save_to_zarr(dataset: xr.Dataset, filename: str, backend: str = 's3'):
     - ValueError: If an unsupported backend is provided.
     """
     gc.collect()
-    
+
     if backend not in ['s3', 'gcs', 'file', 'local', 'custom_backend']:
         raise ValueError(f"Unsupported backend: {backend}")
 


### PR DESCRIPTION
# Pull Request

## Description

i have updated the code that updates the function 'save_to_zarr_to_s3' to accept a parameter indicating the desired backend. I use fsspec to create a file system instance based on the specified backend and save the dataset accordingly.

Fixes #

save_to_zarr function now accepts a backend parameter, which defaults to 's3'. The function checks if the specified backend is supported, and then it uses fsspec to create the appropriate file system instance (fs). The dataset is then saved to Zarr using this file system instance.

Example usage:
save_to_zarr(my_dataset, 's3://my-bucket/my-data.zarr', backend='s3')
save_to_zarr(my_dataset, 'file:///path/to/local/data.zarr', backend='file')
save_to_zarr(my_dataset, 'gcs://my-bucket/my-data.zarr', backend='gcs')

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
