### PR TITLE
Add input validation of directory paths given to satip

### DIFF
--- a/satip/app.py
+++ b/satip/app.py
@@ -129,17 +129,15 @@ def run(
     utils.setupLogging()
 
     try:
-
         if save_dir != "./":
             log.info("Checking if save_dir directory exists")
             if utils.check_path_is_exists_and_directory(save_dir):
                 log.info("save_dir directory exists, continuing execution")
-        
+
         if save_dir_native != "./raw":
             log.info("Checking if save_dir_native directory exists")
             if utils.check_path_is_exists_and_directory(save_dir_native):
                 log.info("save_dir_native directory exists, continuing execution")
-
 
         log.info(
             f'Running application and saving to "{save_dir}"',
@@ -159,8 +157,9 @@ def run(
                 download_manager.cleanup_datatailor()
                 return
             start_date = pd.Timestamp(start_time, tz="UTC") - pd.Timedelta(history)
-            log.info(f"Fetching datasets for {start_date} - {start_time}",
-                     memory=utils.get_memory())
+            log.info(
+                f"Fetching datasets for {start_date} - {start_time}", memory=utils.get_memory()
+            )
             datasets = download_manager.identify_available_datasets(
                 start_date=start_date.strftime("%Y-%m-%d-%H:%M:%S"),
                 end_date=pd.Timestamp(start_time, tz="UTC").strftime("%Y-%m-%d-%H:%M:%S"),
@@ -195,7 +194,7 @@ def run(
                         memory=utils.get_memory(),
                     )
                     datasets = datasets[0:maximum_n_datasets]
-                random.shuffle(datasets) # Shuffle so subsequent runs might download different data
+                random.shuffle(datasets)  # Shuffle so subsequent runs might download different data
                 updated_data = True
                 if use_backup:
                     # Check before downloading each tailored dataset, as it can take awhile

--- a/satip/app.py
+++ b/satip/app.py
@@ -130,6 +130,17 @@ def run(
 
     try:
 
+        if save_dir != "./":
+            log.info("Checking if save_dir directory exists")
+            if utils.check_path_is_exists_and_directory(save_dir):
+                log.info("save_dir directory exists, continuing execution")
+        
+        if save_dir_native != "./raw":
+            log.info("Checking if save_dir_native directory exists")
+            if utils.check_path_is_exists_and_directory(save_dir_native):
+                log.info("save_dir_native directory exists, continuing execution")
+
+
         log.info(
             f'Running application and saving to "{save_dir}"',
             version=satip.__version__,

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -12,6 +12,7 @@ import datetime
 import gc
 import glob
 import os
+from stat import S_ISDIR
 import secrets
 import shutil
 import subprocess
@@ -77,6 +78,26 @@ def setupLogging() -> None:
         ],
     )
 
+def check_path_is_exists_and_directory(path) -> bool:
+    """
+    Check if the provided path exists AND is a directory
+
+    Args:
+        path: The path to check
+
+    Returns:
+        Bool whether the path exists AND is a directory
+    """
+    try:
+        mode = os.lstat(path).st_mode
+    except:
+        log.error(f"No such file or directory: {path}")
+    mode = os.lstat(path).st_mode
+    if S_ISDIR(mode):
+        return True
+    else:
+        log.error("Provided path is a file")
+        raise SystemExit(0)
 
 def format_dt_str(datetime_string):
     """Helper function to get a consistently formatted string."""


### PR DESCRIPTION
…ries

# Pull Request

## Description

This change adds a function to utils.py that checks whether a provided path leads to a directory or just a file

The aforementioned function is then added to the top of app.py to check whether save_dir and/or save_dir_native are valid paths

I want to add this change because this will save resources in case you input a bad path. Otherwise the script proceeds to make expensive API calls to EUMETSAT etc. to then fail at the very end when it tries pushing files to the provided save_dir and/or save_dir_native paths.

This has not been put on the issues page

## How Has This Been Tested?

The following list shows the 3 save_dir paths that been given as arguments and their results after this PR's changes:

1. A save_dir path that leads to a directory, satip continues executing
2. A save_dir path that leads to a file, satip logs the error and halts execution
3. A save_dir path that doesn't lead to a file or directory, satip logs the error and halts execution

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
