### PR TITLE
speed up download_tailored_datasets by adding option to parallel downloads

### DIFF
--- a/satip/app.py
+++ b/satip/app.py
@@ -87,7 +87,7 @@ log = structlog.stdlib.get_logger()
     "--use-backup",
     envvar="USE_BACKUP",
     default=False,
-    help="Option not to sue the RSS imaginary. If True, use the 15 mins data. ",
+    help="Option not to use the RSS imaginary. If True, use the 15 mins data. ",
     type=click.BOOL,
 )
 @click.option(

--- a/satip/app.py
+++ b/satip/app.py
@@ -87,7 +87,7 @@ log = structlog.stdlib.get_logger()
     "--use-backup",
     envvar="USE_BACKUP",
     default=False,
-    help="Option not to use the RSS imaginary. If True, use the 15 mins data. ",
+    help="Option not to sue the RSS imaginary. If True, use the 15 mins data. ",
     type=click.BOOL,
 )
 @click.option(

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -28,6 +28,7 @@ import structlog
 
 from satip import utils
 from satip.data_store import dateset_it_to_filename
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 log = structlog.stdlib.get_logger()
 
@@ -403,6 +404,45 @@ class EUMETSATDownloadManager:
             datasets, product_id=product_id, file_format=file_format, projection=projection, roi=roi
         )
 
+    def download_single_tailored_dataset_with_retry(
+        self,
+        dataset_id,
+        product_id,
+        roi,
+        file_format,
+        projection,
+        attempts=2,
+    ):
+        """
+        Attempts to download a dataset, retrying once if an exception occurs, possibly due to an expired access token.
+
+        Args:
+            dataset_id: Dataset ID to download
+            product_id: Product ID to determine the ID for the request
+            roi: Region of Interest for the area, if None, then no cropping is done
+            file_format: File format of the output, defaults to 'geotiff'
+            projection: Projection for the output, defaults to native projection of 'geographic'
+            attempts: Number of attempts to make (1 attempt + retries)
+        """
+        for attempt in range(attempts):
+            try:
+                self._download_single_tailored_dataset(
+                    dataset_id,
+                    product_id,
+                    roi,
+                    file_format,
+                    projection,
+                )
+                break  # Break if the download succeeds
+            except Exception as e:
+                if attempt < attempts - 1:
+                    # Log and retry, possibly refreshing the token
+                    log.debug("Attempting to refresh the EUMETSAT access token and retry download", parent="DownloadManager")
+                    self.request_access_token()
+                else:
+                    # Final attempt failed, raise exception
+                    raise e
+
     def download_tailored_datasets(
         self,
         datasets,
@@ -410,6 +450,7 @@ class EUMETSATDownloadManager:
         roi: str = None,
         file_format: str = "hrit",
         projection: str = None,
+        parallel: bool = False,
     ):
         """
         Query the data tailor service and write the requested ROI data to disk
@@ -432,27 +473,45 @@ class EUMETSATDownloadManager:
                 parent="DownloadManager",
             )
             return
+        if parallel:
+            with ThreadPoolExecutor() as executor:
+                futures = [
+                    executor.submit(
+                        self.download_single_tailored_dataset_with_retry,
+                        dataset_id,
+                        product_id,
+                        roi,
+                        file_format,
+                        projection,
+                    ) for dataset_id in dataset_ids
+                ]
 
-        for dataset_id in dataset_ids:
-            # Download the raw data
-            try:
-                self._download_single_tailored_dataset(
-                    dataset_id,
-                    product_id=product_id,
-                    roi=roi,
-                    file_format=file_format,
-                    projection=projection,
-                )
-            except Exception:
-                log.debug("The EUMETSAT access token has been refreshed", parent="DownloadManager")
-                self.request_access_token()
-                self._download_single_tailored_dataset(
-                    dataset_id,
-                    product_id=product_id,
-                    roi=roi,
-                    file_format=file_format,
-                    projection=projection,
-                )
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                    except Exception as e:
+                        log.error(f"Failed to download dataset after retrying: {e}", parent="DownloadManager")
+        else:
+            for dataset_id in dataset_ids:
+                # Download the raw data
+                try:
+                    self._download_single_tailored_dataset(
+                        dataset_id,
+                        product_id=product_id,
+                        roi=roi,
+                        file_format=file_format,
+                        projection=projection,
+                    )
+                except Exception:
+                    log.debug("The EUMETSAT access token has been refreshed", parent="DownloadManager")
+                    self.request_access_token()
+                    self._download_single_tailored_dataset(
+                        dataset_id,
+                        product_id=product_id,
+                        roi=roi,
+                        file_format=file_format,
+                        projection=projection,
+                    )
 
     def _download_single_tailored_dataset(
         self,

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -453,6 +453,7 @@ class EUMETSATDownloadManager:
         file_format: str = "hrit",
         projection: str = None,
         parallel: bool = False,
+        concurrency: int = 3,
     ):
         """
         Query the data tailor service and write the requested ROI data to disk
@@ -464,6 +465,8 @@ class EUMETSATDownloadManager:
             file_format: File format to request, multiple options, primarily 'netcdf4' and 'geotiff'
             projection: Projection of the stored data, defaults to 'geographic'
             parallel: Boolean indicating if the download process should be executed in parallel
+            concurrency: maximum concurrency for parallel download if parallel = True,
+                defaults to 3 because the data tailor only takes 3 jobs at a time
         """
 
         # Identifying dataset ids to download
@@ -477,7 +480,7 @@ class EUMETSATDownloadManager:
             )
             return
         if parallel:
-            with ThreadPoolExecutor() as executor:
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
                 futures = [
                     executor.submit(
                         self.download_single_tailored_dataset_with_retry,

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -414,7 +414,8 @@ class EUMETSATDownloadManager:
         attempts=2,
     ):
         """
-        Attempts to download a dataset, retrying once if an exception occurs, possibly due to an expired access token.
+        Attempts to download a dataset, retrying once if an exception occurs, 
+        possibly due to an expired access token.
 
         Args:
             dataset_id: Dataset ID to download
@@ -437,7 +438,10 @@ class EUMETSATDownloadManager:
             except Exception as e:
                 if attempt < attempts - 1:
                     # Log and retry, possibly refreshing the token
-                    log.debug("Attempting to refresh the EUMETSAT access token and retry download", parent="DownloadManager")
+                    log.debug(
+                        "Attempting to refresh the EUMETSAT access token and retry download", 
+                        parent="DownloadManager"
+                    )
                     self.request_access_token()
                 else:
                     # Final attempt failed, raise exception
@@ -461,6 +465,7 @@ class EUMETSATDownloadManager:
             roi: Region of Interest, None if want the whole original area
             file_format: File format to request, multiple options, primarily 'netcdf4' and 'geotiff'
             projection: Projection of the stored data, defaults to 'geographic'
+            parallel: Boolean indicating whether the download process should be executed in parallel.
         """
 
         # Identifying dataset ids to download
@@ -490,7 +495,10 @@ class EUMETSATDownloadManager:
                     try:
                         future.result()
                     except Exception as e:
-                        log.error(f"Failed to download dataset after retrying: {e}", parent="DownloadManager")
+                        log.error(
+                            f"Failed to download dataset after retrying: {e}", 
+                            parent="DownloadManager"
+                        )
         else:
             for dataset_id in dataset_ids:
                 # Download the raw data
@@ -503,7 +511,10 @@ class EUMETSATDownloadManager:
                         projection=projection,
                     )
                 except Exception:
-                    log.debug("The EUMETSAT access token has been refreshed", parent="DownloadManager")
+                    log.debug(
+                        "The EUMETSAT access token has been refreshed", 
+                        parent="DownloadManager"
+                    )
                     self.request_access_token()
                     self._download_single_tailored_dataset(
                         dataset_id,

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -452,8 +452,7 @@ class EUMETSATDownloadManager:
         roi: str = None,
         file_format: str = "hrit",
         projection: str = None,
-        parallel: bool = False,
-        concurrency: int = 3,
+        concurrency: int = 1,
     ):
         """
         Query the data tailor service and write the requested ROI data to disk
@@ -464,9 +463,8 @@ class EUMETSATDownloadManager:
             roi: Region of Interest, None if want the whole original area
             file_format: File format to request, multiple options, primarily 'netcdf4' and 'geotiff'
             projection: Projection of the stored data, defaults to 'geographic'
-            parallel: Boolean indicating if the download process should be executed in parallel
-            concurrency: maximum concurrency for parallel download if parallel = True,
-                defaults to 3 because the data tailor only takes 3 jobs at a time
+            concurrency: concurrency for parallel download, defaults to 1. concurrency should not
+                exceed 3 because the data tailor only takes 3 jobs at a time
         """
 
         # Identifying dataset ids to download
@@ -479,50 +477,25 @@ class EUMETSATDownloadManager:
                 parent="DownloadManager",
             )
             return
-        if parallel:
-            with ThreadPoolExecutor(max_workers=concurrency) as executor:
-                futures = [
-                    executor.submit(
-                        self.download_single_tailored_dataset_with_retry,
-                        dataset_id,
-                        product_id,
-                        roi,
-                        file_format,
-                        projection,
-                    ) for dataset_id in dataset_ids
-                ]
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            futures = [
+                executor.submit(
+                    self.download_single_tailored_dataset_with_retry,
+                    dataset_id,
+                    product_id,
+                    roi,
+                    file_format,
+                    projection,
+                ) for dataset_id in dataset_ids
+            ]
 
-                for future in as_completed(futures):
-                    try:
-                        future.result()
-                    except Exception as e:
-                        log.error(
-                            f"Failed to download dataset after retrying: {e}",
-                            parent="DownloadManager"
-                        )
-        else:
-            for dataset_id in dataset_ids:
-                # Download the raw data
+            for future in as_completed(futures):
                 try:
-                    self._download_single_tailored_dataset(
-                        dataset_id,
-                        product_id=product_id,
-                        roi=roi,
-                        file_format=file_format,
-                        projection=projection,
-                    )
-                except Exception:
-                    log.debug(
-                        "The EUMETSAT access token has been refreshed",
+                    future.result()
+                except Exception as e:
+                    log.error(
+                        f"Failed to download dataset after retrying: {e}",
                         parent="DownloadManager"
-                    )
-                    self.request_access_token()
-                    self._download_single_tailored_dataset(
-                        dataset_id,
-                        product_id=product_id,
-                        roi=roi,
-                        file_format=file_format,
-                        projection=projection,
                     )
 
     def _download_single_tailored_dataset(

--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -413,9 +413,7 @@ class EUMETSATDownloadManager:
         projection,
         attempts=2,
     ):
-        """
-        Attempts to download a dataset, retrying once if an exception occurs, 
-        possibly due to an expired access token.
+        """Attempts to download a dataset, retrying once if an exception occurs
 
         Args:
             dataset_id: Dataset ID to download
@@ -465,7 +463,7 @@ class EUMETSATDownloadManager:
             roi: Region of Interest, None if want the whole original area
             file_format: File format to request, multiple options, primarily 'netcdf4' and 'geotiff'
             projection: Projection of the stored data, defaults to 'geographic'
-            parallel: Boolean indicating whether the download process should be executed in parallel.
+            parallel: Boolean indicating if the download process should be executed in parallel
         """
 
         # Identifying dataset ids to download

--- a/tests/test_eumetsat.py
+++ b/tests/test_eumetsat.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from datetime import datetime, timezone, timedelta
 import pandas as pd
+
 from satip.eumetsat import EUMETSATDownloadManager, eumetsat_filename_to_datetime
 
 
@@ -56,6 +57,7 @@ def test_data_tailor_identify_available_datasets():
         )
 
         assert len(datasets) > 0
+
 
 def test_data_tailor():
     """If there were a test here, there would also be a docstring here."""

--- a/tests/test_eumetsat.py
+++ b/tests/test_eumetsat.py
@@ -58,7 +58,7 @@ def test_data_tailor_identify_available_datasets():
 
         assert len(datasets) > 0
 
-
+'''
 def test_data_tailor():
     """If there were a test here, there would also be a docstring here."""
 
@@ -96,7 +96,7 @@ def test_data_tailor():
 
         native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI_HRV")))
         assert len(native_files) > 0
-
+'''
 
 def test_data_tailor_parallel():
     """If there were a test here, there would also be a docstring here."""
@@ -123,12 +123,12 @@ def test_data_tailor_parallel():
 
         assert len(datasets) > 0
 
-        datasets = datasets[0:3]
-        print(datasets)
+        datasets = datasets[0:5]
+        #print(datasets)
         download_manager.download_tailored_datasets(
             datasets,
             product_id="EO:EUM:DAT:MSG:HRSEVIRI",
-            parallel=True
+            parallel=False
         )
 
         native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI")))

--- a/tests/test_eumetsat.py
+++ b/tests/test_eumetsat.py
@@ -4,7 +4,6 @@ import os
 import tempfile
 from datetime import datetime, timezone, timedelta
 import pandas as pd
-
 from satip.eumetsat import EUMETSATDownloadManager, eumetsat_filename_to_datetime
 
 
@@ -58,7 +57,6 @@ def test_data_tailor_identify_available_datasets():
 
         assert len(datasets) > 0
 
-
 def test_data_tailor():
     """If there were a test here, there would also be a docstring here."""
 
@@ -89,6 +87,46 @@ def test_data_tailor():
         download_manager.download_tailored_datasets(
             datasets,
             product_id="EO:EUM:DAT:MSG:HRSEVIRI",
+        )
+
+        native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI")))
+        assert len(native_files) > 0
+
+        native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI_HRV")))
+        assert len(native_files) > 0
+
+
+def test_data_tailor_parallel():
+    """If there were a test here, there would also be a docstring here."""
+
+    user_key = os.environ.get("EUMETSAT_USER_KEY")
+    user_secret = os.environ.get("EUMETSAT_USER_SECRET")
+
+    start_date = datetime.now(tz=timezone.utc) - timedelta(hours=2)
+    end_date = datetime.now(tz=timezone.utc)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        download_manager = EUMETSATDownloadManager(
+            user_key=user_key,
+            user_secret=user_secret,
+            data_dir=tmpdirname,
+            native_file_dir=tmpdirname,
+        )
+
+        datasets = download_manager.identify_available_datasets(
+            start_date=start_date.strftime("%Y-%m-%d-%H:%M:%S"),
+            end_date=end_date.strftime("%Y-%m-%d-%H:%M:%S"),
+            product_id="EO:EUM:DAT:MSG:HRSEVIRI",
+        )
+
+        assert len(datasets) > 0
+
+        datasets = datasets[0:3]
+        print(datasets)
+        download_manager.download_tailored_datasets(
+            datasets,
+            product_id="EO:EUM:DAT:MSG:HRSEVIRI",
+            parallel=True
         )
 
         native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI")))

--- a/tests/test_eumetsat.py
+++ b/tests/test_eumetsat.py
@@ -83,52 +83,13 @@ def test_data_tailor():
         )
 
         assert len(datasets) > 0
-        # only download one dataset
-        datasets = datasets[0:1]
-
-        download_manager.download_tailored_datasets(
-            datasets,
-            product_id="EO:EUM:DAT:MSG:HRSEVIRI",
-        )
-
-        native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI")))
-        assert len(native_files) > 0
-
-        native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI_HRV")))
-        assert len(native_files) > 0
-
-
-def test_data_tailor_parallel():
-    """If there were a test here, there would also be a docstring here."""
-
-    user_key = os.environ.get("EUMETSAT_USER_KEY")
-    user_secret = os.environ.get("EUMETSAT_USER_SECRET")
-
-    start_date = datetime.now(tz=timezone.utc) - timedelta(hours=2)
-    end_date = datetime.now(tz=timezone.utc)
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        download_manager = EUMETSATDownloadManager(
-            user_key=user_key,
-            user_secret=user_secret,
-            data_dir=tmpdirname,
-            native_file_dir=tmpdirname,
-        )
-
-        datasets = download_manager.identify_available_datasets(
-            start_date=start_date.strftime("%Y-%m-%d-%H:%M:%S"),
-            end_date=end_date.strftime("%Y-%m-%d-%H:%M:%S"),
-            product_id="EO:EUM:DAT:MSG:HRSEVIRI",
-        )
-
-        assert len(datasets) > 0
 
         datasets = datasets[0:3]
         #print(datasets)
         download_manager.download_tailored_datasets(
             datasets,
             product_id="EO:EUM:DAT:MSG:HRSEVIRI",
-            parallel=True
+            concurrency=3
         )
 
         native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI")))

--- a/tests/test_eumetsat.py
+++ b/tests/test_eumetsat.py
@@ -58,7 +58,7 @@ def test_data_tailor_identify_available_datasets():
 
         assert len(datasets) > 0
 
-'''
+
 def test_data_tailor():
     """If there were a test here, there would also be a docstring here."""
 
@@ -96,7 +96,7 @@ def test_data_tailor():
 
         native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI_HRV")))
         assert len(native_files) > 0
-'''
+
 
 def test_data_tailor_parallel():
     """If there were a test here, there would also be a docstring here."""
@@ -123,12 +123,12 @@ def test_data_tailor_parallel():
 
         assert len(datasets) > 0
 
-        datasets = datasets[0:5]
+        datasets = datasets[0:3]
         #print(datasets)
         download_manager.download_tailored_datasets(
             datasets,
             product_id="EO:EUM:DAT:MSG:HRSEVIRI",
-            parallel=False
+            parallel=True
         )
 
         native_files = list(glob.glob(os.path.join(tmpdirname, "*HRSEVIRI")))


### PR DESCRIPTION
# Pull Request

## Description

Trying to speed up download_tailored_datasets by adding an option to parallel downloads using `concurrent.futures`

Fixes https://github.com/openclimatefix/Satip/issues/144

With parallelization:
![image](https://github.com/openclimatefix/Satip/assets/40121574/53e0c454-3efd-44dd-8b0b-5c5e7102e929)



## How Has This Been Tested?

- [x] Yes
Tested with `test_data_tailor_parallel`, a new test I added in test_eumetsat.py. Parallelization reduces the test time from `18:10` to `07:41`.
![image](https://github.com/openclimatefix/Satip/assets/40121574/f4f0fc81-0338-4117-a45e-eb2faad00d56)


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
