### PR TITLE
Remove sleep command left on accident

### DIFF
--- a/satip/download.py
+++ b/satip/download.py
@@ -170,7 +170,6 @@ def _download_time_range(
     complete = False
     while not complete:
         try:
-            time.sleep(np.random.randint(0, 600))
             download_manager.download_date_range(
                 format_dt_str(start_time),
                 format_dt_str(end_time),


### PR DESCRIPTION
# Pull Request

## Description

Fixes https://github.com/openclimatefix/Satip/issues/157
remove sleep command left on accident, which improves downloading time
Discussions: https://github.com/openclimatefix/Satip/issues/157#issuecomment-2023223214

## How Has This Been Tested?

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
