### PR TITLE
switch to 15 mintues data, if less than 1.5 hour of 5 min data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -117,3 +117,4 @@ zarr==2.17.0
 zict==3.0.0
 zipp==3.17.0
 sentry-sdk
+flexparser-0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,4 +117,4 @@ zarr==2.17.0
 zict==3.0.0
 zipp==3.17.0
 sentry-sdk
-flexparser-0.3.1
+flexparser==0.3.1

--- a/satip/app.py
+++ b/satip/app.py
@@ -247,7 +247,7 @@ def run(
                 # If there is less than this, we move over to the 15 minute data
                 # note we need history data to be larger than this.
                 n_datasets_needed = int(pd.to_timedelta(history) / pd.Timedelta("5 min") * 0.75)
-                if (len(datasets) < 18) or use_hr_serviri:
+                if (len(datasets) < n_datasets_needed) or use_hr_serviri:
                     log.warn(
                         f"No RSS Imagery available or using backup ({use_hr_serviri=}), "
                         f"falling back to 15-minutely data",

--- a/satip/app.py
+++ b/satip/app.py
@@ -243,7 +243,7 @@ def run(
                 )
 
                 # Check if any RSS imagery is available, if not, fall back to 15 minutely data
-                # We check if there are less than 12 datasets, which is 1 hour of 5 minute data.
+                # We check if there are less than 7 datasets, which is 30 minutes of 5 minute data.
                 # If there is less than this, we move over to the 15 minute data
                 if (len(datasets) < 7) or use_hr_serviri:
                     log.warn(

--- a/satip/app.py
+++ b/satip/app.py
@@ -243,9 +243,10 @@ def run(
                 )
 
                 # Check if any RSS imagery is available, if not, fall back to 15 minutely data
-                # We check if there are less than 18 datasets,
-                # which is 1 hour and 30 minutes of 5 minute data.
+                # We want to check if there is at least 75% of the history data available
                 # If there is less than this, we move over to the 15 minute data
+                # note we need history data to be larger than this.
+                n_datasets_needed = int(pd.to_timedelta(history) / pd.Timedelta("5 min") * 0.75)
                 if (len(datasets) < 18) or use_hr_serviri:
                     log.warn(
                         f"No RSS Imagery available or using backup ({use_hr_serviri=}), "

--- a/satip/app.py
+++ b/satip/app.py
@@ -243,9 +243,10 @@ def run(
                 )
 
                 # Check if any RSS imagery is available, if not, fall back to 15 minutely data
-                # We check if there are less than 7 datasets, which is 30 minutes of 5 minute data.
+                # We check if there are less than 18 datasets,
+                # which is 1 hour and 30 minutes of 5 minute data.
                 # If there is less than this, we move over to the 15 minute data
-                if (len(datasets) < 7) or use_hr_serviri:
+                if (len(datasets) < 18) or use_hr_serviri:
                     log.warn(
                         f"No RSS Imagery available or using backup ({use_hr_serviri=}), "
                         f"falling back to 15-minutely data",

--- a/satip/app.py
+++ b/satip/app.py
@@ -245,7 +245,7 @@ def run(
                 # Check if any RSS imagery is available, if not, fall back to 15 minutely data
                 # We check if there are less than 12 datasets, which is 1 hour of 5 minute data.
                 # If there is less than this, we move over to the 15 minute data
-                if (len(datasets) < 12) or use_hr_serviri:
+                if (len(datasets) < 7) or use_hr_serviri:
                     log.warn(
                         f"No RSS Imagery available or using backup ({use_hr_serviri=}), "
                         f"falling back to 15-minutely data",

--- a/satip/app.py
+++ b/satip/app.py
@@ -241,8 +241,11 @@ def run(
                     start_date=start_date.strftime("%Y-%m-%d-%H:%M:%S"),
                     end_date=pd.Timestamp(start_time, tz="UTC").strftime("%Y-%m-%d-%H:%M:%S"),
                 )
+
                 # Check if any RSS imagery is available, if not, fall back to 15 minutely data
-                if (len(datasets) == 0) or use_hr_serviri:
+                # We check if there are less than 12 datasets, which is 1 hour of 5 minute data.
+                # If there is less than this, we move over to the 15 minute data
+                if (len(datasets) < 12) or use_hr_serviri:
                     log.warn(
                         f"No RSS Imagery available or using backup ({use_hr_serviri=}), "
                         f"falling back to 15-minutely data",


### PR DESCRIPTION
# Pull Request

## Description

Switch over to 15 minutes data, if less than 1 hour and 30 hour of 5 min data. Currently it only swicthes if there is no data
#286 , 

We do this by checking if there is 75% of the "history" data we need. In live history is set to 120 minutes

had to pin flex-parser - https://github.com/hgrecco/flexparser/issues/12

## How Has This Been Tested?

CI tests

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
