### PR TITLE
dont remove 15 minutes timestamp

### DIFF
--- a/satip/filenames.py
+++ b/satip/filenames.py
@@ -13,7 +13,6 @@ def get_datetime_from_filename(filename: str, strip_hrv: bool = False) -> pd.Tim
     """
 
     filename = filename.replace("iodc_", "")
-    filename = filename.replace("15_", "")
 
     if strip_hrv:
         filename = filename.replace("hrv_", "")

--- a/tests/unit_test/test_filenames.py
+++ b/tests/unit_test/test_filenames.py
@@ -14,10 +14,10 @@ def test_get_time_from_filename():
     assert datetime == "hrv_202408261815"
 
     datetime = get_datetime_from_filename("folder/15_hrv_202408261815.zarr.zip")
-    assert datetime == "hrv_202408261815"
+    assert datetime == "15_hrv_202408261815"
 
     datetime = get_datetime_from_filename("folder/hrv_202408261815.zarr.zip", strip_hrv=True)
     assert datetime == pd.Timestamp("2024-08-26 18:15", tz="UTC")
 
     datetime = get_datetime_from_filename("folder/15_hrv_202408261815.zarr.zip", strip_hrv=True)
-    assert datetime == pd.Timestamp("2024-08-26 18:15", tz="UTC")
+    assert datetime == "15_202408261815"


### PR DESCRIPTION
# Pull Request

## Description

Fix for 1st pull of 15 minute data. This makes sure it dont get confused by 5 minute data, and not download the new 15 min data

#313 

## How Has This Been Tested?

CI tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
