### PR TITLE
Allow NaNs in datasets

### DIFF
--- a/satip/utils.py
+++ b/satip/utils.py
@@ -335,7 +335,7 @@ def do_v15_rescaling(
     dataarray -= mins
     dataarray /= new_max
     dataarray *= upper_bound
-    dataarray = dataarray.round().clip(min=0, max=upper_bound).astype(np.int16)
+    dataarray = dataarray.round().clip(min=0, max=upper_bound).astype(np.float32)
     return dataarray
 
 

--- a/satip/utils.py
+++ b/satip/utils.py
@@ -335,7 +335,7 @@ def do_v15_rescaling(
     dataarray -= mins
     dataarray /= new_max
     dataarray *= upper_bound
-    dataarray = dataarray.round().clip(min=0, max=upper_bound).astype(np.float32)
+    dataarray = dataarray.clip(min=0, max=upper_bound).astype(np.float32)
     return dataarray
 
 


### PR DESCRIPTION
In the GCP archive, the bits of the image which are off the earth disk are filled with NaNs. There are even times when some random scattered pixels over the earth are NaNs, (probably just a measurements error from the satellite). In the production data, there are no NaNs and the pieces of the image off the earth disk are all zeros.

This is an issue for the cloudcasting model. When training, all the pixels that are NaN are flagged to the model so it knows where they are. This isn't possible in production since all NaNs are now zero, but not all the zero values were NaN - at night the visual channels go dark, for instance.

This PR updates the type of the dataset to float32, which implements NaN.