### PR TITLE
raise error if 2 failed attemps

### DIFF
--- a/satip/eumetsat.py
+++ b/satip/eumetsat.py
@@ -438,6 +438,7 @@ class EUMETSATDownloadManager:
             attempts: Number of attempts to make (1 attempt + retries)
         """
         for attempt in range(attempts):
+            log.info(f"Attempt {attempt + 1} of {attempts}", parent="DownloadManager")
             try:
                 self._download_single_tailored_dataset(
                     dataset_id,
@@ -511,6 +512,7 @@ class EUMETSATDownloadManager:
                         f"Failed to download dataset after retrying: {e}",
                         parent="DownloadManager"
                     )
+                    raise e
 
     def _download_single_tailored_dataset(
         self,
@@ -667,7 +669,7 @@ class EUMETSATDownloadManager:
                 log.debug(
                     f"Attempt {attempt}: Found {len(running_customisations)} "
                     f"running customisations, of which "
-                    f"{len(inactive_customisations)} are inactive and"
+                    f"{len(inactive_customisations)} are inactive and "
                     f"{len(failed_customisations)} are failed "
                 )
 


### PR DESCRIPTION
# Pull Request

## Description

If the data taylor customisation failed twice, then fail the consumer. This will stop gaps appearing in the data. 

## How Has This Been Tested?

no tested, very hard too. CI test will fail as 5 min data is down right now

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
