### PR TITLE
update example cord transform function

### DIFF
--- a/satip/geospatial.py
+++ b/satip/geospatial.py
@@ -6,8 +6,8 @@ https://epsg.io/27700.
 
   Typical usage example:
 
-  from satip.geospatial import lat_lon_to_osb
-  lat_lon_to_osb(numeric_list_of_latitudes, numeric_list_of_longitudes)
+  from satip.geospatial import lat_lon_to_osgb
+  lat_lon_to_osgb(numeric_list_of_latitudes, numeric_list_of_longitudes)
 """
 
 from numbers import Number


### PR DESCRIPTION
# Pull Request

## Description

Small change to the example use of the `lat_lon_to_osgb` function, which previously was missing the letter `g` in osgb.

Fixes #

## How Has This Been Tested?

Function will now load with the updated example

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
